### PR TITLE
Make user email nullable

### DIFF
--- a/cc-webapp/backend/alembic/env.py
+++ b/cc-webapp/backend/alembic/env.py
@@ -74,9 +74,9 @@ def run_migrations_online() -> None:
     # Create a new section in the config for the database URL
     # if it doesn't already exist.
     section = config.config_ini_section
-    if not config.has_section(section):
-        config.add_section(section)
-    config.set_section_option(section, "sqlalchemy.url", db_url)
+    # Alembic's Config object doesn't support has_section/add_section like
+    # ConfigParser. Use set_main_option to set the database URL directly.
+    config.set_main_option("sqlalchemy.url", db_url)
 
     connectable = engine_from_config(
         config.get_section(section), # Use the modified section

--- a/cc-webapp/backend/alembic/versions/c01e1021ed94_make_user_email_nullable.py
+++ b/cc-webapp/backend/alembic/versions/c01e1021ed94_make_user_email_nullable.py
@@ -1,0 +1,28 @@
+"""make_user_email_nullable
+
+Revision ID: c01e1021ed94
+Revises: 
+Create Date: 2025-06-04 16:13:13.380090
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c01e1021ed94'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column('users', 'email', existing_type=sa.String(), nullable=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.alter_column('users', 'email', existing_type=sa.String(), nullable=False)

--- a/cc-webapp/backend/app/models.py
+++ b/cc-webapp/backend/app/models.py
@@ -9,7 +9,7 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
-    email = Column(String, unique=True, index=True, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=True)
     nickname = Column(String(50), unique=True, nullable=True)
     password_hash = Column(String(255), nullable=True)
     invite_code = Column(String(6), nullable=True)

--- a/cc-webapp/backend/tests/test_notification.py
+++ b/cc-webapp/backend/tests/test_notification.py
@@ -51,7 +51,7 @@ def db_session() -> Generator[Session, None, None]:
 def seed_notifications_data(db: Session, user_id: int, num_pending: int, num_sent: int, email_suffix: str = ""):
     user = db.query(User).filter_by(id=user_id).first()
     if not user:
-        user = User(id=user_id, email=f"notify_user{user_id}{email_suffix}@example.com")
+        user = User(id=user_id)
         db.add(user)
         try:
             db.commit()

--- a/cc-webapp/backend/tests/test_rewards.py
+++ b/cc-webapp/backend/tests/test_rewards.py
@@ -51,7 +51,7 @@ def db_session() -> Generator[Session, None, None]:
 def seed_rewards_data(db: Session, user_id: int, num_rewards: int, email_suffix: str = "") -> List[UserReward]:
     user = db.query(User).filter_by(id=user_id).first()
     if not user:
-        user = User(id=user_id, email=f"rewards_user{user_id}{email_suffix}@example.com")
+        user = User(id=user_id)
         db.add(user)
         # Must commit user if it's new before adding rewards that reference it,
         # or ensure user_id in UserReward is just an int and FK is handled by DB.
@@ -142,7 +142,7 @@ def test_get_rewards_page_out_of_bounds(db_session: Session):
 
 def test_get_rewards_no_rewards(db_session: Session):
     # Ensure user exists but has no rewards
-    user = User(id=USER_ID_FOR_REWARDS_TESTS, email=f"rewards_user{USER_ID_FOR_REWARDS_TESTS}_norewards@example.com")
+    user = User(id=USER_ID_FOR_REWARDS_TESTS)
     db_session.add(user)
     db_session.commit()
 

--- a/cc-webapp/backend/tests/test_unlock.py
+++ b/cc-webapp/backend/tests/test_unlock.py
@@ -69,7 +69,7 @@ def seed_initial_data(db: Session, user_id: int, rfm_group: str = "Whale", email
     # User
     test_user = db.query(User).filter_by(id=user_id).first()
     if not test_user:
-        test_user = User(id=user_id, email=f"user{user_id}{email_suffix}@example.com")
+        test_user = User(id=user_id)
         db.add(test_user)
 
     # UserSegment


### PR DESCRIPTION
## Summary
- allow `User.email` to be nullable
- add Alembic migration for making `users.email` nullable
- update tests so users can be created without emails
- fix Alembic env to set DB URL correctly

## Testing
- `pytest -q` *(fails: User with id not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406fdc6fc483299a3ce7dee080cc8c