### PR TITLE
Add auth router and unify env names

### DIFF
--- a/cc-webapp/backend/app/main.py
+++ b/cc-webapp/backend/app/main.py
@@ -23,9 +23,7 @@ try:
 except Exception:  # noqa: BLE001
     sentry_sdk = None
     FastApiIntegration = None
-import os # For Sentry DSN from env var
-from pydantic import BaseModel # For request/response models
-from typing import Optional
+import os  # For Sentry DSN from env var
 
 from app.routers import (
     actions,
@@ -38,6 +36,7 @@ from app.routers import (
     adult_content,
     corporate,
     users,
+    auth,
 )
 
 # --- Sentry Initialization (Placeholder - should be configured properly with DSN) ---
@@ -125,35 +124,7 @@ app.include_router(adult_content.router, prefix="/api")
 app.include_router(corporate.router, prefix="/api")
 app.include_router(users.router, prefix="/api")
 
-# Request/Response Models
-class UserLogin(BaseModel):
-    """사용자 로그인 스키마"""
-    user_id: str
-    password: str
-
-class LoginResponse(BaseModel):
-    """로그인 응답 스키마"""
-    token: str
-    user_id: str
-    message: Optional[str] = None
-
-@app.post("/login", response_model=LoginResponse, tags=["Authentication"])
-async def login(user: UserLogin):
-    """
-    사용자 로그인 엔드포인트
-
-    - **user_id**: 사용자 ID
-    - **password**: 비밀번호
-    - 성공 시 JWT 토큰 반환
-    """
-    # 실제 로직은 추후 구현
-    if user.user_id == "test" and user.password == "password":
-        return {
-            "token": "sample_jwt_token",
-            "user_id": user.user_id,
-            "message": "로그인 성공"
-        }
-    raise HTTPException(status_code=401, detail="인증 실패")
+app.include_router(auth.router, prefix="/api")
 
 @app.get("/health", tags=["System"])
 async def health_check():

--- a/cc-webapp/backend/app/routers/__init__.py
+++ b/cc-webapp/backend/app/routers/__init__.py
@@ -1,0 +1,15 @@
+from . import actions, adult_content, corporate, feedback, gacha, notification, rewards, unlock, user_segments, users, auth
+
+__all__ = [
+    "actions",
+    "adult_content",
+    "corporate",
+    "feedback",
+    "gacha",
+    "notification",
+    "rewards",
+    "unlock",
+    "user_segments",
+    "users",
+    "auth",
+]

--- a/cc-webapp/backend/app/routers/auth.py
+++ b/cc-webapp/backend/app/routers/auth.py
@@ -1,0 +1,37 @@
+from datetime import datetime, timedelta
+import os
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from jose import jwt
+
+router = APIRouter(prefix="/auth", tags=["Auth"])
+
+# Environment variables with canonical names
+JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "changeme")
+JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
+JWT_EXPIRE_MINUTES = int(os.getenv("JWT_EXPIRE_MINUTES", "30"))
+INITIAL_CYBER_TOKENS = int(os.getenv("INITIAL_CYBER_TOKENS", "200"))
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+@router.post("/login", response_model=TokenResponse)
+async def login(req: LoginRequest):
+    """Simple login that issues a JWT."""
+    # Placeholder authentication logic
+    if not (req.username == "test" and req.password == "password"):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    expire = datetime.utcnow() + timedelta(minutes=JWT_EXPIRE_MINUTES)
+    payload = {
+        "sub": req.username,
+        "exp": expire,
+        "initial_tokens": INITIAL_CYBER_TOKENS,
+    }
+    token = jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+    return TokenResponse(access_token=token)


### PR DESCRIPTION
## Summary
- add `/auth/login` router referencing canonical environment variables
- expose new router in `__init__` and include in `main.py`
- remove old login stub and unused imports
- confirm env vars in compose files and `.env.example`

## Testing
- `pytest -q` *(fails: User not found errors)*

------
https://chatgpt.com/codex/tasks/task_e_684071f8516c8329ad1744f5dc41d0ea