### PR TITLE
Implement token transfer and invite admin API

### DIFF
--- a/cc-webapp/backend/app/models.py
+++ b/cc-webapp/backend/app/models.py
@@ -1,9 +1,19 @@
-from sqlalchemy import Column, Integer, String, DateTime, Float, ForeignKey, Boolean # Added Boolean
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Float,
+    ForeignKey,
+    Boolean,
+    JSON,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.declarative import declarative_base
 from datetime import datetime
 
 Base = declarative_base()
+
 
 class User(Base):
     __tablename__ = "users"
@@ -18,10 +28,30 @@ class User(Base):
     segment_label = Column(String(20), default="Low")
 
     actions = relationship("UserAction", back_populates="user")
-    segment = relationship("UserSegment", uselist=False, back_populates="user") # One-to-one
+    segment = relationship(
+        "UserSegment", uselist=False, back_populates="user"
+    )  # One-to-one
     rewards = relationship("UserReward", back_populates="user")
     site_visits = relationship("SiteVisit", back_populates="user")
-    notifications = relationship("Notification", back_populates="user") # Added for Notification
+    notifications = relationship(
+        "Notification", back_populates="user"
+    )  # Added for Notification
+    streaks = relationship("UserStreak", back_populates="user")
+    game_logs = relationship("GameLog", back_populates="user")
+    coins = relationship("UserCoin", back_populates="user")
+    items = relationship("UserItem", back_populates="user")
+    sent_transfers = relationship(
+        "TokenTransfer",
+        foreign_keys="TokenTransfer.from_user_id",
+        back_populates="from_user",
+    )
+    received_transfers = relationship(
+        "TokenTransfer",
+        foreign_keys="TokenTransfer.to_user_id",
+        back_populates="to_user",
+    )
+    login_history = relationship("LoginHistory", back_populates="user")
+
 
 class UserAction(Base):
     __tablename__ = "user_actions"
@@ -30,61 +60,80 @@ class UserAction(Base):
     user_id = Column(Integer, ForeignKey("users.id"), index=True, nullable=False)
     action_type = Column(String, index=True, nullable=False)
     timestamp = Column(DateTime, default=datetime.utcnow, index=True)
-    value = Column(Float, default=0.0) # For monetary value in RFM
+    value = Column(Float, default=0.0)  # For monetary value in RFM
 
     user = relationship("User", back_populates="actions")
+
 
 class UserSegment(Base):
     __tablename__ = "user_segments"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), unique=True, index=True, nullable=False)
+    user_id = Column(
+        Integer, ForeignKey("users.id"), unique=True, index=True, nullable=False
+    )
 
-    rfm_group = Column(String, index=True, nullable=True) # e.g., Whale, Medium, Low
-    risk_profile = Column(String, index=True, nullable=True) # e.g., High, Medium, Low (can be from other logic)
-    streak_count = Column(Integer, default=0) # Example of another segmentation attribute
+    rfm_group = Column(String, index=True, nullable=True)  # e.g., Whale, Medium, Low
+    risk_profile = Column(
+        String, index=True, nullable=True
+    )  # e.g., High, Medium, Low (can be from other logic)
+    streak_count = Column(
+        Integer, default=0
+    )  # Example of another segmentation attribute
 
     last_updated = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     user = relationship("User", back_populates="segment")
 
+
 class SiteVisit(Base):
     __tablename__ = "site_visits"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), index=True, nullable=False) # Relates to User model
-    source = Column(String(50), nullable=False) # e.g., "webapp", "email_link"
+    user_id = Column(
+        Integer, ForeignKey("users.id"), index=True, nullable=False
+    )  # Relates to User model
+    source = Column(String(50), nullable=False)  # e.g., "webapp", "email_link"
     visit_timestamp = Column(DateTime, default=datetime.utcnow)
 
     user = relationship("User", back_populates="site_visits")
+
 
 class UserReward(Base):
     __tablename__ = "user_rewards"
 
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), index=True, nullable=False)
-    reward_type = Column(String(50), index=True, nullable=False)  # e.g., "COIN", "BADGE", "CONTENT_UNLOCK"
-    reward_value = Column(String(255), nullable=False) # Stores amount for COIN, badge name for BADGE, item_id for UNLOCK
+    reward_type = Column(
+        String(50), index=True, nullable=False
+    )  # e.g., "COIN", "BADGE", "CONTENT_UNLOCK"
+    reward_value = Column(
+        String(255), nullable=False
+    )  # Stores amount for COIN, badge name for BADGE, item_id for UNLOCK
     awarded_at = Column(DateTime, default=datetime.utcnow, index=True)
-    trigger_action_id = Column(Integer, ForeignKey("user_actions.id"), nullable=True) # Optional: link to action that triggered reward
+    trigger_action_id = Column(
+        Integer, ForeignKey("user_actions.id"), nullable=True
+    )  # Optional: link to action that triggered reward
 
     user = relationship("User", back_populates="rewards")
     # Optional: if you want to link a reward back to the specific action that triggered it
     # trigger_action = relationship("UserAction") # Define how UserAction relates back if needed
 
+
 class AdultContent(Base):
     __tablename__ = "adult_content"
 
     id = Column(Integer, primary_key=True, index=True)
-    stage = Column(Integer, unique=True, nullable=False, index=True) # e.g., 1, 2, 3
+    stage = Column(Integer, unique=True, nullable=False, index=True)  # e.g., 1, 2, 3
     name = Column(String(100), nullable=False)
     description = Column(String(255), nullable=True)
     thumbnail_url = Column(String(255), nullable=True)
-    media_url = Column(String(255), nullable=True) # Video or full-res image
+    media_url = Column(String(255), nullable=True)  # Video or full-res image
     # Defines the minimum segment level required to unlock this content.
     # This level is derived from UserSegment.rfm_group (e.g., Low=1, Medium=2, Whale=3).
     required_segment_level = Column(Integer, default=1, nullable=False)
     # Add any other relevant fields like 'duration', 'tags', etc.
+
 
 class Notification(Base):
     __tablename__ = "notifications"
@@ -97,6 +146,123 @@ class Notification(Base):
     sent_at = Column(DateTime, nullable=True)
 
     user = relationship("User", back_populates="notifications")
+
+
+class InviteCode(Base):
+    """Invitation codes for new user sign-ups"""
+
+    __tablename__ = "invite_codes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    code = Column(String(12), unique=True, index=True)
+    created_by = Column(Integer, ForeignKey("users.id"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    expires_at = Column(DateTime)
+    is_used = Column(Boolean, default=False)
+
+    creator = relationship("User")
+
+
+class UserStreak(Base):
+    """연승/연패 기록"""
+
+    __tablename__ = "user_streaks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    game_type = Column(String, nullable=False)
+    current_streak = Column(Integer, default=0)
+    max_win_streak = Column(Integer, default=0)
+    max_lose_streak = Column(Integer, default=0)
+    last_updated = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="streaks")
+
+
+class GameLog(Base):
+    """게임 플레이 기록"""
+
+    __tablename__ = "game_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    game_type = Column(String, nullable=False)
+    bet_amount = Column(Integer, nullable=False)
+    win_amount = Column(Integer, nullable=False)
+    net_change = Column(Integer, nullable=False)
+    result_type = Column(String, nullable=False)
+    result_details = Column(JSON, nullable=True)
+    played_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="game_logs")
+
+
+class UserCoin(Base):
+    """사용자 게임 내 코인"""
+
+    __tablename__ = "user_coins"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    amount = Column(Integer, nullable=False)
+    source = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="coins")
+
+
+class UserItem(Base):
+    """사용자 보유 아이템"""
+
+    __tablename__ = "user_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    item_id = Column(String, nullable=False)
+    item_name = Column(String, nullable=False)
+    item_type = Column(String, nullable=False)
+    quantity = Column(Integer, nullable=False, default=1)
+    acquired_at = Column(DateTime, default=datetime.utcnow)
+    expires_at = Column(DateTime, nullable=True)
+    used_at = Column(DateTime, nullable=True)
+
+    user = relationship("User", back_populates="items")
+
+
+class TokenTransfer(Base):
+    """사용자 간 토큰 전송 기록"""
+
+    __tablename__ = "token_transfers"
+
+    id = Column(Integer, primary_key=True, index=True)
+    from_user_id = Column(Integer, ForeignKey("users.id"))
+    to_user_id = Column(Integer, ForeignKey("users.id"))
+    amount = Column(Integer, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    status = Column(String, nullable=False)
+    error_message = Column(String, nullable=True)
+
+    from_user = relationship(
+        "User", foreign_keys=[from_user_id], back_populates="sent_transfers"
+    )
+    to_user = relationship(
+        "User", foreign_keys=[to_user_id], back_populates="received_transfers"
+    )
+
+
+class LoginHistory(Base):
+    """로그인 이력"""
+
+    __tablename__ = "login_history"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    ip_address = Column(String, nullable=True)
+    user_agent = Column(String, nullable=True)
+    success = Column(Boolean, default=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="login_history")
 
 
 # In User model, add the other side of the relationship if you want two-way population

--- a/cc-webapp/backend/app/routers/auth.py
+++ b/cc-webapp/backend/app/routers/auth.py
@@ -1,10 +1,12 @@
 from datetime import datetime, timedelta
 import os
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
+import random
+import string
 from jose import jwt, JWTError
 from passlib.context import CryptContext
 
@@ -17,11 +19,31 @@ JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "changeme")
 JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
 JWT_EXPIRE_MINUTES = int(os.getenv("JWT_EXPIRE_MINUTES", "60"))
 INITIAL_CYBER_TOKENS = int(os.getenv("INITIAL_CYBER_TOKENS", "200"))
+ADMIN_USER_IDS = [
+    int(i) for i in os.getenv("ADMIN_USER_IDS", "1").split(",")
+]  # simple admin list
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
+
+login_attempts: dict[str, dict] = {}
+
+
+def generate_random_code(length: int = 12) -> str:
+    chars = string.ascii_letters + string.digits
+    return "".join(random.choice(chars) for _ in range(length))
+
+
+def get_admin_user(
+    user_id: int = Depends(lambda token: get_user_from_token(token)),
+    db: Session = Depends(get_db),
+):
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user or user.id not in ADMIN_USER_IDS:
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+    return user
 
 
 class LoginRequest(BaseModel):
@@ -33,6 +55,20 @@ class SignUpRequest(BaseModel):
     nickname: str
     password: str
     invite_code: str
+
+
+class InviteCodeResponse(BaseModel):
+    id: int
+    code: str
+    expires_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class UserUpdateRequest(BaseModel):
+    nickname: Optional[str] = None
+    password: Optional[str] = None
 
 
 class VerifyInviteRequest(BaseModel):
@@ -55,7 +91,9 @@ class UserMe(BaseModel):
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=JWT_EXPIRE_MINUTES))
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=JWT_EXPIRE_MINUTES)
+    )
     to_encode.update({"exp": expire})
     return jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
 
@@ -76,19 +114,59 @@ def get_user_from_token(token: str = Depends(oauth2_scheme)):
 
 @router.post("/verify-invite")
 async def verify_invite(req: VerifyInviteRequest, db: Session = Depends(get_db)):
-    code = db.query(models.InviteCode).filter(models.InviteCode.code == req.code, models.InviteCode.is_used == False).first()
+    code = (
+        db.query(models.InviteCode)
+        .filter(models.InviteCode.code == req.code, models.InviteCode.is_used == False)
+        .first()
+    )
     return {"valid": bool(code)}
+
+
+@router.post("/admin/generate-invite", response_model=List[InviteCodeResponse])
+async def generate_invite_codes(
+    count: int = 10,
+    expires_in_days: int = 30,
+    admin: models.User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    codes: list[models.InviteCode] = []
+    for _ in range(count):
+        code = generate_random_code(12)
+        expires_at = datetime.utcnow() + timedelta(days=expires_in_days)
+        invite = models.InviteCode(
+            code=code,
+            created_by=admin.id,
+            expires_at=expires_at,
+            is_used=False,
+        )
+        db.add(invite)
+        codes.append(invite)
+    db.commit()
+    for inv in codes:
+        db.refresh(inv)
+    return codes
 
 
 @router.post("/signup", response_model=TokenResponse)
 async def signup(data: SignUpRequest, db: Session = Depends(get_db)):
     if db.query(models.User).filter(models.User.nickname == data.nickname).first():
         raise HTTPException(status_code=400, detail="Nickname already taken")
-    invite = db.query(models.InviteCode).filter(models.InviteCode.code == data.invite_code, models.InviteCode.is_used == False).first()
+    invite = (
+        db.query(models.InviteCode)
+        .filter(
+            models.InviteCode.code == data.invite_code,
+            models.InviteCode.is_used == False,
+        )
+        .first()
+    )
     if not invite:
         raise HTTPException(status_code=400, detail="Invalid invite code")
     hashed_password = pwd_context.hash(data.password)
-    user = models.User(nickname=data.nickname, password_hash=hashed_password, invite_code=data.invite_code)
+    user = models.User(
+        nickname=data.nickname,
+        password_hash=hashed_password,
+        invite_code=data.invite_code,
+    )
     db.add(user)
     invite.is_used = True
     db.commit()
@@ -98,17 +176,76 @@ async def signup(data: SignUpRequest, db: Session = Depends(get_db)):
     return TokenResponse(access_token=access_token)
 
 
+@router.put("/profile", response_model=UserMe)
+async def update_profile(
+    data: UserUpdateRequest,
+    user_id: int = Depends(get_user_from_token),
+    db: Session = Depends(get_db),
+):
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    if data.nickname and data.nickname != user.nickname:
+        existing = (
+            db.query(models.User).filter(models.User.nickname == data.nickname).first()
+        )
+        if existing:
+            raise HTTPException(status_code=400, detail="Nickname already taken")
+        user.nickname = data.nickname
+    if data.password:
+        user.password_hash = pwd_context.hash(data.password)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
 @router.post("/login", response_model=TokenResponse)
-async def login(data: LoginRequest, db: Session = Depends(get_db)):
+async def login(
+    data: LoginRequest,
+    db: Session = Depends(get_db),
+    request: Request = None,
+):
+    client_ip = request.client.host if request else "unknown"
+
+    if client_ip in login_attempts and login_attempts[client_ip]["count"] >= 5:
+        last = login_attempts[client_ip]["timestamp"]
+        if datetime.utcnow() - last < timedelta(minutes=15):
+            raise HTTPException(
+                status_code=429, detail="Too many login attempts. Try again later."
+            )
+        login_attempts[client_ip] = {"count": 0, "timestamp": datetime.utcnow()}
+
     user = db.query(models.User).filter(models.User.nickname == data.nickname).first()
     if not user or not pwd_context.verify(data.password, user.password_hash):
+        if client_ip not in login_attempts:
+            login_attempts[client_ip] = {"count": 1, "timestamp": datetime.utcnow()}
+        else:
+            login_attempts[client_ip]["count"] += 1
+            login_attempts[client_ip]["timestamp"] = datetime.utcnow()
         raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    if client_ip in login_attempts:
+        del login_attempts[client_ip]
+
+    history = models.LoginHistory(
+        user_id=user.id,
+        ip_address=client_ip,
+        user_agent=request.headers.get("user-agent", "unknown")
+        if request
+        else "unknown",
+        success=True,
+    )
+    db.add(history)
+    db.commit()
+
     access_token = create_access_token({"sub": str(user.id)})
     return TokenResponse(access_token=access_token)
 
 
 @router.get("/me", response_model=UserMe)
-async def get_me(user_id: int = Depends(get_user_from_token), db: Session = Depends(get_db)):
+async def get_me(
+    user_id: int = Depends(get_user_from_token), db: Session = Depends(get_db)
+):
     user = db.query(models.User).filter(models.User.id == user_id).first()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/cc-webapp/backend/app/services/token_service.py
+++ b/cc-webapp/backend/app/services/token_service.py
@@ -1,6 +1,7 @@
 """Token service that persists balances to both Redis and database for durability."""
 
 import os
+from datetime import datetime
 from typing import Optional
 from sqlalchemy.orm import Session
 
@@ -24,8 +25,10 @@ if redis is not None:
     except Exception:
         redis_client = None
 
+
 def _redis_key(user_id: int) -> str:
     return f"user:{user_id}:cyber_token_balance"
+
 
 def _sync_db_balance(db: Session, user_id: int, new_balance: int) -> None:
     """Update user's cyber token balance in the database without committing."""
@@ -37,9 +40,10 @@ def _sync_db_balance(db: Session, user_id: int, new_balance: int) -> None:
     # Use flush to push the update so callers can decide when to commit
     db.flush()
 
+
 def add_tokens(user_id: int, amount: int, db: Optional[Session] = None) -> int:
     """Add cyber tokens to a user and return the new balance.
-    
+
     Updates both Redis and DB for durability. If db is provided, caller is
     responsible for committing the session.
     """
@@ -49,16 +53,17 @@ def add_tokens(user_id: int, amount: int, db: Optional[Session] = None) -> int:
     else:
         balance = user_tokens.get(user_id, 0) + amount
         user_tokens[user_id] = balance
-    
+
     # Update database if session provided
     if db:
         _sync_db_balance(db, user_id, balance)
-    
+
     return balance
+
 
 def deduct_tokens(user_id: int, amount: int, db: Optional[Session] = None) -> int:
     """Deduct tokens if possible and return the remaining balance.
-    
+
     Updates both Redis and DB for durability. If db is provided, caller is
     responsible for committing the session.
     """
@@ -86,16 +91,17 @@ def deduct_tokens(user_id: int, amount: int, db: Optional[Session] = None) -> in
             raise ValueError("Insufficient tokens")
         new_balance = balance - amount
         user_tokens[user_id] = new_balance
-    
+
     # Update database if session provided
     if db:
         _sync_db_balance(db, user_id, new_balance)
-    
+
     return new_balance
+
 
 def get_balance(user_id: int, db: Optional[Session] = None) -> int:
     """Get user's current token balance.
-    
+
     Prioritizes Redis for speed but falls back to DB if needed.
     """
     # Try Redis first for speed
@@ -103,11 +109,11 @@ def get_balance(user_id: int, db: Optional[Session] = None) -> int:
         val = redis_client.get(_redis_key(user_id))
         if val is not None:
             return int(val)
-    
+
     # Fall back to in-memory cache
     if user_id in user_tokens:
         return user_tokens[user_id]
-    
+
     # Fall back to database if provided
     if db:
         user = db.query(models.User).filter(models.User.id == user_id).first()
@@ -119,22 +125,151 @@ def get_balance(user_id: int, db: Optional[Session] = None) -> int:
             else:
                 user_tokens[user_id] = balance
             return balance
-    
+
     # Default to 0 if no balance found
     return 0
+
 
 def sync_from_db(user_id: int, db: Session) -> int:
     """Sync Redis/memory balance from DB for consistency."""
     user = db.query(models.User).filter(models.User.id == user_id).first()
     if not user:
         raise ValueError("User not found")
-    
+
     balance = user.cyber_token_balance or 0
-    
+
     # Update Redis or in-memory fallback
     if redis_client:
         redis_client.set(_redis_key(user_id), balance)
     else:
         user_tokens[user_id] = balance
-        
+
     return balance
+
+
+def bulk_add_tokens(
+    user_ids: list[int], amount: int, db: Session | None = None
+) -> dict[int, int]:
+    """Add tokens to multiple users in bulk."""
+    results: dict[int, int] = {}
+    for uid in user_ids:
+        try:
+            new_balance = add_tokens(uid, amount, db)
+            results[uid] = new_balance
+        except Exception as e:  # noqa: BLE001
+            if db:
+                db.rollback()
+            results[uid] = None
+    if db:
+        db.commit()
+    return results
+
+
+def transfer_tokens(
+    from_user_id: int, to_user_id: int, amount: int, db: Session
+) -> dict:
+    """Transfer tokens between users with transaction logging."""
+    try:
+        deduct_tokens(from_user_id, amount, db)
+        add_tokens(to_user_id, amount, db)
+        transfer_log = models.TokenTransfer(
+            from_user_id=from_user_id,
+            to_user_id=to_user_id,
+            amount=amount,
+            timestamp=datetime.utcnow(),
+            status="COMPLETED",
+        )
+        db.add(transfer_log)
+        db.commit()
+        return {
+            "from_balance": get_balance(from_user_id, db),
+            "to_balance": get_balance(to_user_id, db),
+            "transfer_id": transfer_log.id,
+            "amount": amount,
+            "timestamp": transfer_log.timestamp.isoformat(),
+        }
+    except Exception as e:  # noqa: BLE001
+        db.rollback()
+        transfer_log = models.TokenTransfer(
+            from_user_id=from_user_id,
+            to_user_id=to_user_id,
+            amount=amount,
+            timestamp=datetime.utcnow(),
+            status="FAILED",
+            error_message=str(e),
+        )
+        db.add(transfer_log)
+        db.commit()
+        raise
+
+
+def get_token_history(
+    user_id: int, limit: int = 10, db: Session | None = None
+) -> list[dict]:
+    """Retrieve a combined list of token history events."""
+    if db is None:
+        return []
+
+    transfers_sent = (
+        db.query(models.TokenTransfer)
+        .filter(models.TokenTransfer.from_user_id == user_id)
+        .order_by(models.TokenTransfer.timestamp.desc())
+        .limit(limit)
+        .all()
+    )
+
+    transfers_received = (
+        db.query(models.TokenTransfer)
+        .filter(models.TokenTransfer.to_user_id == user_id)
+        .order_by(models.TokenTransfer.timestamp.desc())
+        .limit(limit)
+        .all()
+    )
+
+    game_logs = (
+        db.query(models.GameLog)
+        .filter(models.GameLog.user_id == user_id)
+        .order_by(models.GameLog.played_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+    all_history: list[dict] = []
+
+    for tr in transfers_sent:
+        all_history.append(
+            {
+                "type": "TRANSFER_SENT",
+                "amount": -tr.amount,
+                "timestamp": tr.timestamp,
+                "details": {"to_user_id": tr.to_user_id, "status": tr.status},
+            }
+        )
+
+    for tr in transfers_received:
+        all_history.append(
+            {
+                "type": "TRANSFER_RECEIVED",
+                "amount": tr.amount,
+                "timestamp": tr.timestamp,
+                "details": {"from_user_id": tr.from_user_id, "status": tr.status},
+            }
+        )
+
+    for log in game_logs:
+        all_history.append(
+            {
+                "type": f"GAME_{log.game_type.upper()}",
+                "amount": log.net_change,
+                "timestamp": log.played_at,
+                "details": {
+                    "game_type": log.game_type,
+                    "bet_amount": log.bet_amount,
+                    "win_amount": log.win_amount,
+                    "result_type": log.result_type,
+                },
+            }
+        )
+
+    all_history.sort(key=lambda x: x["timestamp"], reverse=True)
+    return all_history[:limit]


### PR DESCRIPTION
## Summary
- add InviteCode, token transfer, and gameplay models
- expand auth router with admin invite generation, profile update, and login throttling
- extend token service with bulk, transfer and history helpers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: User with id not found, login test unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_68407df4eff88329b7691506bc19b04b