### PR TITLE
Implement basic games router

### DIFF
--- a/cc-webapp/backend/app/main.py
+++ b/cc-webapp/backend/app/main.py
@@ -30,6 +30,7 @@ from typing import Optional
 from app.routers import (
     actions,
     gacha,
+    games,
     rewards,
     unlock,
     notification,
@@ -117,6 +118,7 @@ app.add_middleware(
 # Register API routers
 app.include_router(actions.router, prefix="/api")
 app.include_router(gacha.router, prefix="/api")
+app.include_router(games.router, prefix="/api")
 app.include_router(rewards.router, prefix="/api")
 app.include_router(unlock.router, prefix="/api")
 app.include_router(notification.router, prefix="/api")

--- a/cc-webapp/backend/app/routers/games.py
+++ b/cc-webapp/backend/app/routers/games.py
@@ -1,0 +1,272 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List, Optional
+import random
+import logging
+from pydantic import BaseModel
+
+from ..database import get_db
+from .. import models
+from ..services import token_service
+
+try:
+    import redis
+except Exception:  # noqa: BLE001
+    redis = None
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+REDIS_URL = "redis://localhost:6379/0"
+redis_client = None
+if redis is not None:
+    try:
+        redis_client = redis.Redis.from_url(REDIS_URL, decode_responses=True)
+        redis_client.ping()
+    except Exception:  # noqa: BLE001
+        logger.warning("Redis unavailable, streaks will be stored in memory")
+        redis_client = None
+
+# In-memory fallback for streak counts
+streak_cache: dict[int, int] = {}
+
+def _streak_key(user_id: int) -> str:
+    return f"user:{user_id}:streak_count"
+
+
+def get_streak(user_id: int) -> int:
+    if redis_client:
+        val = redis_client.get(_streak_key(user_id))
+        return int(val) if val is not None else 0
+    return streak_cache.get(user_id, 0)
+
+
+def set_streak(user_id: int, value: int) -> None:
+    if redis_client:
+        redis_client.set(_streak_key(user_id), value)
+    else:
+        streak_cache[user_id] = value
+
+
+def get_user_segment(db: Session, user_id: int) -> str:
+    seg = db.query(models.UserSegment).filter(models.UserSegment.user_id == user_id).first()
+    return seg.rfm_group if seg and seg.rfm_group else "Low"
+
+
+class SlotSpinRequest(BaseModel):
+    user_id: int
+
+class SlotSpinResponse(BaseModel):
+    result: str
+    tokens_change: int
+    balance: int
+    streak: int
+    animation: Optional[str]
+
+
+@router.post("/games/slot-spin", response_model=SlotSpinResponse, tags=["games"])
+def slot_spin(request: SlotSpinRequest, db: Session = Depends(get_db)):
+    user_id = request.user_id
+    try:
+        token_service.deduct_tokens(user_id, 2, db)
+    except ValueError:
+        raise HTTPException(status_code=402, detail="Insufficient tokens")
+
+    segment = get_user_segment(db, user_id)
+    streak = get_streak(user_id)
+    win_prob = 0.10 + min(streak * 0.01, 0.05)
+    if segment == "Whale":
+        win_prob += 0.02
+    elif segment == "Low":
+        win_prob -= 0.02
+    jackpot_prob = 0.01
+
+    spin = random.random()
+    result = "lose"
+    reward = 0
+    animation = "lose"
+    if streak >= 7:
+        result = "win"
+        reward = 10
+        animation = "force_win"
+        streak = 0
+    elif spin < jackpot_prob:
+        result = "jackpot"
+        reward = 100
+        animation = "jackpot"
+        streak = 0
+    elif spin < jackpot_prob + win_prob:
+        result = "win"
+        reward = 10
+        animation = "win"
+        streak = 0
+    else:
+        streak += 1
+
+    if reward:
+        token_service.add_tokens(user_id, reward, db)
+
+    set_streak(user_id, streak)
+
+    balance = token_service.get_balance(user_id, db)
+
+    action = models.UserAction(user_id=user_id, action_type="SLOT_SPIN", value=-2)
+    db.add(action)
+    db.commit()
+
+    return SlotSpinResponse(
+        result=result,
+        tokens_change=reward - 2,
+        balance=balance,
+        streak=streak,
+        animation=animation,
+    )
+
+
+class RouletteSpinRequest(BaseModel):
+    user_id: int
+    bet_amount: int
+    bet_type: str
+    value: Optional[str] = None
+
+class RouletteSpinResponse(BaseModel):
+    winning_number: int
+    result: str
+    tokens_change: int
+    balance: int
+    animation: Optional[str]
+
+
+@router.post("/games/roulette-spin", response_model=RouletteSpinResponse, tags=["games"])
+def roulette_spin(request: RouletteSpinRequest, db: Session = Depends(get_db)):
+    user_id = request.user_id
+    bet = max(1, min(request.bet_amount, 50))
+    try:
+        token_service.deduct_tokens(user_id, bet, db)
+    except ValueError:
+        raise HTTPException(status_code=402, detail="Insufficient tokens")
+
+    segment = get_user_segment(db, user_id)
+    edge_map = {"Whale": 0.05, "Medium": 0.10, "Low": 0.15}
+    house_edge = edge_map.get(segment, 0.10)
+
+    number = random.randint(0, 36)
+    result = "lose"
+    payout = 0
+    animation = "lose"
+
+    if request.bet_type == "number" and request.value is not None:
+        if number == int(request.value):
+            payout = int(bet * 35 * (1 - house_edge))
+    elif request.bet_type == "color" and request.value in {"red", "black"}:
+        color_map = {
+            "red": set(range(1, 37, 2)),
+            "black": set(range(2, 37, 2)),
+        }
+        if number != 0 and number in color_map[request.value]:
+            payout = int(bet * (1 - house_edge))
+    elif request.bet_type == "odd_even" and request.value in {"odd", "even"}:
+        if number != 0 and (number % 2 == 0) == (request.value == "even"):
+            payout = int(bet * (1 - house_edge))
+
+    if payout:
+        result = "win"
+        animation = "win"
+        token_service.add_tokens(user_id, payout, db)
+
+    balance = token_service.get_balance(user_id, db)
+
+    action = models.UserAction(user_id=user_id, action_type="ROULETTE_SPIN", value=-bet)
+    db.add(action)
+    db.commit()
+
+    return RouletteSpinResponse(
+        winning_number=number,
+        result=result,
+        tokens_change=payout - bet,
+        balance=balance,
+        animation=animation,
+    )
+
+
+class GachaPullRequest(BaseModel):
+    user_id: int
+    count: int = 1
+
+class GachaResult(BaseModel):
+    rarity: str
+
+class GachaPullResponse(BaseModel):
+    results: List[GachaResult]
+    tokens_change: int
+    balance: int
+
+
+RARITY_TABLE = [
+    ("Legendary", 0.005),
+    ("Epic", 0.045),
+    ("Rare", 0.25),
+    ("Common", 0.70),
+]
+
+def _gacha_count_key(user_id: int) -> str:
+    return f"user:{user_id}:gacha_count"
+
+def _gacha_history_key(user_id: int) -> str:
+    return f"user:{user_id}:gacha_history"
+
+
+@router.post("/games/gacha-pull", response_model=GachaPullResponse, tags=["games"])
+def gacha_pull(request: GachaPullRequest, db: Session = Depends(get_db)):
+    user_id = request.user_id
+    pulls = 10 if request.count >= 10 else 1
+    cost = 450 if pulls == 10 else 50
+    try:
+        token_service.deduct_tokens(user_id, cost, db)
+    except ValueError:
+        raise HTTPException(status_code=402, detail="Insufficient tokens")
+
+    results: List[GachaResult] = []
+
+    count_key = _gacha_count_key(user_id)
+    history_key = _gacha_history_key(user_id)
+    current_count = int(redis_client.get(count_key) or 0) if redis_client else 0
+
+    history = []
+    if redis_client:
+        history = redis_client.lrange(history_key, 0, 9)
+
+    for _ in range(pulls):
+        current_count += 1
+        pity = current_count >= 90
+        rnd = random.random()
+        cumulative = 0.0
+        rarity = "Common"
+        for name, prob in RARITY_TABLE:
+            adj_prob = prob
+            if history and name in history:
+                adj_prob *= 0.5
+            cumulative += adj_prob
+            if rnd <= cumulative:
+                rarity = name
+                break
+        if pity and rarity not in {"Epic", "Legendary"}:
+            rarity = "Epic"
+            current_count = 0
+        results.append(GachaResult(rarity=rarity))
+        history.insert(0, rarity)
+        history = history[:10]
+
+    if redis_client:
+        redis_client.set(count_key, current_count)
+        if history:
+            redis_client.delete(history_key)
+            redis_client.rpush(history_key, *history)
+
+    balance = token_service.get_balance(user_id, db)
+
+    action = models.UserAction(user_id=user_id, action_type="GACHA_PULL", value=-cost)
+    db.add(action)
+    db.commit()
+
+    return GachaPullResponse(results=results, tokens_change=-cost, balance=balance)


### PR DESCRIPTION
## Summary
- add games router with slot-spin, roulette-spin, and gacha-pull endpoints
- register new router in FastAPI app

## Testing
- `pytest -q` *(fails: test_auth.py::test_login_success, test_notification.py::test_get_one_pending_notification, test_notification.py::test_get_all_pending_notifications_sequentially, test_notification.py::test_get_pending_notifications_none_pending, test_notification.py::test_notification_not_re_sent_after_processing, test_rewards.py::test_get_rewards_first_page, test_rewards.py::test_get_rewards_second_page, test_rewards.py::test_get_rewards_last_page_partial, test_rewards.py::test_get_rewards_page_out_of_bounds, test_rewards.py::test_get_rewards_no_rewards, test_rewards.py::test_get_rewards_default_pagination, test_unlock.py::test_unlock_stages_sequentially, test_unlock.py::test_unlock_insufficient_segment, test_unlock.py::test_unlock_content_stage_not_found)*

------
https://chatgpt.com/codex/tasks/task_e_68407f82e0c88329a9b8ca82d5b1c9de