### PR TITLE
Add docs titles endpoint

### DIFF
--- a/cc-webapp/backend/app/main.py
+++ b/cc-webapp/backend/app/main.py
@@ -41,6 +41,7 @@ from app.routers import (
     adult_content,
     corporate,
     users,
+    doc_titles,
 
     auth,
     chat,
@@ -139,6 +140,7 @@ app.include_router(feedback.router, prefix="/api")
 app.include_router(adult_content.router, prefix="/api")
 app.include_router(corporate.router, prefix="/api")
 app.include_router(users.router, prefix="/api")
+app.include_router(doc_titles.router, prefix="/api")
 
 app.include_router(auth.router, prefix="/api")
 app.include_router(chat.router)

--- a/cc-webapp/backend/app/routers/doc_titles.py
+++ b/cc-webapp/backend/app/routers/doc_titles.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from fastapi import APIRouter, HTTPException
+import re
+
+router = APIRouter()
+
+@router.get("/docs/titles", response_model=list)
+def get_docs_titles():
+    """Return document names and their H1-H3 titles from the docs folder."""
+    try:
+        base_path = Path(__file__).resolve().parents[4]
+        docs_path = base_path / "docs"
+        result = []
+        if not docs_path.is_dir():
+            raise FileNotFoundError("Docs directory not found")
+        for md_file in sorted(docs_path.glob("*.md")):
+            titles = []
+            for line in md_file.read_text(encoding="utf-8").splitlines():
+                match = re.match(r"^(#{1,3})\s+(.*)", line)
+                if match:
+                    level = len(match.group(1))
+                    title = match.group(2).strip()
+                    titles.append({"level": level, "title": title})
+            result.append({"document": md_file.name, "titles": titles})
+        return result
+    except Exception as e:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- add endpoint to list documentation titles
- hook new router in FastAPI app

## Testing
- `pytest -q` *(fails: 13 failed, 51 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6841187bd9f8832990e1a55d3c198110