### PR TITLE
Improve user segment schema and user checks

### DIFF
--- a/cc-webapp/backend/app/models.py
+++ b/cc-webapp/backend/app/models.py
@@ -47,9 +47,17 @@ class UserSegment(Base):
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), unique=True, index=True, nullable=False)
 
+    # Human readable name of the segment (e.g. "Whale", "Medium")
+    name = Column(String(50), nullable=True)
+
     rfm_group = Column(String, index=True, nullable=True) # e.g., Whale, Medium, Low
     risk_profile = Column(String, index=True, nullable=True) # e.g., High, Medium, Low (can be from other logic)
     streak_count = Column(Integer, default=0) # Example of another segmentation attribute
+
+    # Store raw scores used for RFM segmentation so that logic can be revisited later
+    recency_score = Column(Integer, default=0)
+    frequency_score = Column(Integer, default=0)
+    monetary_score = Column(Integer, default=0)
 
     last_updated = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/cc-webapp/backend/app/services/user_service.py
+++ b/cc-webapp/backend/app/services/user_service.py
@@ -1,0 +1,14 @@
+from sqlalchemy.orm import Session
+from app import models
+
+class UserService:
+    """Utility service for common user lookups."""
+
+    def __init__(self, db: Session) -> None:
+        self.db = db
+
+    def get_user_or_error(self, user_id: int) -> models.User:
+        user = self.db.query(models.User).filter(models.User.id == user_id).first()
+        if not user:
+            raise ValueError("존재하지 않는 사용자")
+        return user

--- a/cc-webapp/backend/app/utils/segment_utils.py
+++ b/cc-webapp/backend/app/utils/segment_utils.py
@@ -123,17 +123,25 @@ def compute_rfm_and_update_segments(db: Session):
         current_time = datetime.utcnow()
         if user_segment:
             user_segment.rfm_group = rfm_group
+            user_segment.name = rfm_group
+            user_segment.recency_score = r_score
+            user_segment.frequency_score = f_score
+            user_segment.monetary_score = m_score
             user_segment.last_updated = current_time
-            updated_count +=1
+            updated_count += 1
         else:
             user_segment = UserSegment(
                 user_id=user_id,
                 rfm_group=rfm_group,
+                name=rfm_group,
+                recency_score=r_score,
+                frequency_score=f_score,
+                monetary_score=m_score,
                 # risk_profile will be set by another process or if logic is added here
-                last_updated=current_time
+                last_updated=current_time,
             )
             db.add(user_segment)
-            created_count +=1
+            created_count += 1
 
         # print(f"User {user_id}: R={recency_days}d (Score {r_score}), F={frequency} (Score {f_score}), M={monetary_value} (Score {m_score}) -> RFM Group: {rfm_group}")
 

--- a/cc-webapp/backend/tests/test_adult_content_service.py
+++ b/cc-webapp/backend/tests/test_adult_content_service.py
@@ -32,7 +32,7 @@ class TestAdultContentService(unittest.TestCase):
         self.mock_age_verification_service.is_user_age_verified.return_value = True
 
     def test_get_user_segment_max_order_whale(self):
-        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Whale")
+        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Whale", name="Whale")
         self.mock_db_session.query(UserSegment).filter(UserSegment.user_id == self.user_id).first.return_value = mock_segment
         order = self.adult_content_service._get_user_segment_max_order(self.user_id)
         self.assertEqual(order, USER_SEGMENT_ACCESS_ORDER["Whale"])
@@ -64,7 +64,7 @@ class TestAdultContentService(unittest.TestCase):
 
     def test_get_content_access_level_segment_access(self):
         # User is "Medium" segment, no specific unlocks for this content
-        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Medium")
+        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Medium", name="Medium")
         self.mock_db_session.query(UserSegment).filter(UserSegment.user_id == self.user_id).first.return_value = mock_segment
         self.mock_db_session.query(UserReward).filter(...).all.return_value = [] # No specific unlocks
 
@@ -75,7 +75,7 @@ class TestAdultContentService(unittest.TestCase):
         self.mock_db_session.query(AdultContent).filter(AdultContent.id == self.content_id).first.return_value = self.mock_content
 
         # Assume user is "Low" segment, has purchased "Partial" for this content
-        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Low")
+        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Low", name="Low")
         self.mock_db_session.query(UserSegment).filter(UserSegment.user_id == self.user_id).first.return_value = mock_segment
         unlock_rewards = [UserReward(user_id=self.user_id, reward_type="CONTENT_UNLOCK", reward_value=f"{self.content_id}_Partial")]
         self.mock_db_session.query(UserReward).filter(...).all.return_value = unlock_rewards
@@ -102,7 +102,7 @@ class TestAdultContentService(unittest.TestCase):
         self.mock_db_session.query(AdultContent).filter(AdultContent.id == self.content_id).first.return_value = self.mock_content
 
         # User is "Low" segment, no prior unlocks for this content
-        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Low")
+        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Low", name="Low")
         self.mock_db_session.query(UserSegment).filter(UserSegment.user_id == self.user_id).first.return_value = mock_segment
         self.mock_db_session.query(UserReward).filter(...).all.return_value = []
 
@@ -126,7 +126,7 @@ class TestAdultContentService(unittest.TestCase):
 
     def test_unlock_content_stage_insufficient_tokens(self):
         self.mock_db_session.query(AdultContent).filter(AdultContent.id == self.content_id).first.return_value = self.mock_content
-        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Low")
+        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Low", name="Low")
         self.mock_db_session.query(UserSegment).filter(UserSegment.user_id == self.user_id).first.return_value = mock_segment
         self.mock_db_session.query(UserReward).filter(...).all.return_value = []
 
@@ -147,7 +147,7 @@ class TestAdultContentService(unittest.TestCase):
 
         # User is "Low" (Teaser access by default for content1 if its req_segment_level allows)
         # and has no specific unlocks for content2
-        mock_segment_low = UserSegment(user_id=self.user_id, rfm_group="Low")
+        mock_segment_low = UserSegment(user_id=self.user_id, rfm_group="Low", name="Low")
         self.mock_db_session.query(UserSegment).filter(UserSegment.user_id == self.user_id).first.return_value = mock_segment_low
 
         # Mock _get_user_unlocked_stage_order:
@@ -190,7 +190,7 @@ class TestAdultContentService(unittest.TestCase):
 
     def test_upgrade_access_temporarily_simulated_success(self):
         self.mock_db_session.query(User).filter(User.id == self.user_id).first.return_value = self.mock_user
-        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Low") # Current segment
+        mock_segment = UserSegment(user_id=self.user_id, rfm_group="Low", name="Low") # Current segment
         self.mock_db_session.query(UserSegment).filter(UserSegment.user_id == self.user_id).first.return_value = mock_segment
 
         self.mock_token_service.deduct_tokens.return_value = 1000 # Remaining tokens

--- a/cc-webapp/backend/tests/test_notification.py
+++ b/cc-webapp/backend/tests/test_notification.py
@@ -164,7 +164,7 @@ def test_get_pending_notifications_none_pending(db_session: Session):
 def test_get_pending_notifications_user_not_found(db_session: Session): # db_session will clean up
     response = client.get("/api/notification/pending/99999") # Non-existent user
     assert response.status_code == 404, response.text
-    assert "User with id 99999 not found" in response.json()["detail"] # Match actual error message
+    assert "존재하지 않는 사용자" in response.json()["detail"]
 
 # This test name from prompt was "idempotency_after_error", but the logic for that is hard to test
 # without complex mocking of db.commit(). The current endpoint is not idempotent on error by design

--- a/cc-webapp/backend/tests/test_rewards.py
+++ b/cc-webapp/backend/tests/test_rewards.py
@@ -157,7 +157,7 @@ def test_get_rewards_no_rewards(db_session: Session):
 def test_get_rewards_user_not_found(db_session: Session): # db_session cleans up
     response = client.get("/api/users/9999/rewards") # Non-existent user
     assert response.status_code == 404, response.text
-    assert "User with id 9999 not found" in response.json()["detail"]
+    assert "존재하지 않는 사용자" in response.json()["detail"]
 
 def test_get_rewards_default_pagination(db_session: Session):
     seed_rewards_data(db_session, user_id=USER_ID_FOR_REWARDS_TESTS, num_rewards=25, email_suffix="_pg_default")

--- a/cc-webapp/backend/tests/test_unlock.py
+++ b/cc-webapp/backend/tests/test_unlock.py
@@ -161,7 +161,7 @@ def test_unlock_insufficient_segment(db_session: Session):
 def test_unlock_user_not_found(db_session: Session): # db_session fixture will clean tables
     response = client.get("/api/unlock?user_id=999") # Non-existent user
     assert response.status_code == 404, response.text
-    assert "User not found" in response.json()["detail"]
+    assert "존재하지 않는 사용자" in response.json()["detail"]
 
 
 def test_unlock_content_stage_not_found(db_session: Session):

--- a/cc-webapp/backend/tests/test_user_segments.py
+++ b/cc-webapp/backend/tests/test_user_segments.py
@@ -19,7 +19,7 @@ def test_recommendation_whale_high_risk_high_streak(MockSessionLocal, mock_redis
     # Mock DB session and query
     mock_db_session = MagicMock()
     # Create a UserSegment instance to be returned by the mock query
-    mock_user_segment_db_instance = UserSegment(user_id=1, rfm_group="Whale", risk_profile="High-Risk")
+    mock_user_segment_db_instance = UserSegment(user_id=1, rfm_group="Whale", name="Whale", risk_profile="High-Risk")
     mock_db_session.query(UserSegment).filter().first.return_value = mock_user_segment_db_instance
 
     # Configure the context manager __enter__ to return the mock_db_session
@@ -56,7 +56,7 @@ def test_recommendation_whale_high_risk_high_streak(MockSessionLocal, mock_redis
 @patch('app.routers.user_segments.SessionLocal')
 def test_recommendation_medium_low_risk_zero_streak(MockSessionLocal, mock_redis_client_instance):
     mock_db_session = MagicMock()
-    mock_user_segment_db_instance = UserSegment(user_id=2, rfm_group="Medium", risk_profile="Low-Risk")
+    mock_user_segment_db_instance = UserSegment(user_id=2, rfm_group="Medium", name="Medium", risk_profile="Low-Risk")
     mock_db_session.query(UserSegment).filter().first.return_value = mock_user_segment_db_instance
     MockSessionLocal.return_value.__enter__.return_value = mock_db_session
 
@@ -78,7 +78,7 @@ def test_recommendation_medium_low_risk_zero_streak(MockSessionLocal, mock_redis
 @patch('app.routers.user_segments.SessionLocal')
 def test_recommendation_low_rfm_no_streak_in_redis(MockSessionLocal, mock_redis_client_instance):
     mock_db_session = MagicMock()
-    mock_user_segment_db_instance = UserSegment(user_id=3, rfm_group="Low", risk_profile="Medium-Risk")
+    mock_user_segment_db_instance = UserSegment(user_id=3, rfm_group="Low", name="Low", risk_profile="Medium-Risk")
     mock_db_session.query(UserSegment).filter().first.return_value = mock_user_segment_db_instance
     MockSessionLocal.return_value.__enter__.return_value = mock_db_session
 
@@ -107,21 +107,14 @@ def test_recommendation_user_segment_not_found(MockSessionLocal, mock_redis_clie
         mock_redis_client_instance.get.return_value = "5" # Some streak
 
     response = client.get("/api/user-segments/999/recommendation") # Non-existent user
-    assert response.status_code == 200 # Endpoint uses defaults, doesn't 404
-    data = response.json()
-    assert data["rfm_group"] == "Low" # Default
-    assert data["risk_profile"] == "Unknown" # Default
-    assert data["streak_count"] == 5
-    # Expected: 0.25 (base for Low RFM default) + 5 * 0.01 (streak) = 0.30
-    assert data["recommended_reward_probability"] == 0.30
-    assert data["recommended_time_window"] == "next 24 hours" # For Low RFM default
+    assert response.status_code == 404
 
 # Test Case 5: Redis client is None (simulating connection failure at startup)
 @patch('app.routers.user_segments.redis_client', None) # Patch redis_client to be None
 @patch('app.routers.user_segments.SessionLocal')
 def test_recommendation_redis_client_none(MockSessionLocal):
     mock_db_session = MagicMock()
-    mock_user_segment_db_instance = UserSegment(user_id=1, rfm_group="Whale", risk_profile="High-Risk")
+    mock_user_segment_db_instance = UserSegment(user_id=1, rfm_group="Whale", name="Whale", risk_profile="High-Risk")
     mock_db_session.query(UserSegment).filter().first.return_value = mock_user_segment_db_instance
     MockSessionLocal.return_value.__enter__.return_value = mock_db_session
 


### PR DESCRIPTION
## Summary
- expand `UserSegment` model with a human-readable name and score fields
- compute RFM scores when updating segments
- add a small `UserService` for consistent user existence checks
- integrate `UserService` into unlock, rewards and user segment routers
- expire old flash offers instead of raising an error

## Testing
- `pytest -q cc-webapp/backend/tests` *(fails: AttributeError in AdultContentService and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68412814aaf0832998fdb8817f2d2659