### PR TITLE
Fix reward pagination tests

### DIFF
--- a/cc-webapp/backend/app/services/reward_service.py
+++ b/cc-webapp/backend/app/services/reward_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError # Import SQLAlchemyError
@@ -19,7 +19,7 @@ class RewardService:
         awarded_at: datetime = None,
     ) -> models.UserReward:
         if awarded_at is None:
-            awarded_at = datetime.utcnow()
+            awarded_at = datetime.now(timezone.utc)
 
         reward_value = f"{content_id}_{stage_name}"
 

--- a/cc-webapp/backend/tests/test_rewards.py
+++ b/cc-webapp/backend/tests/test_rewards.py
@@ -31,7 +31,13 @@ def override_get_db() -> Generator[Session, None, None]:
         if db:
             db.close()
 
-app.dependency_overrides[get_db] = override_get_db
+@pytest.fixture(autouse=True)
+def override_dependency() -> Generator[None, None, None]:
+    original = app.dependency_overrides.copy()
+    app.dependency_overrides[get_db] = override_get_db
+    yield
+    app.dependency_overrides = original
+
 client = TestClient(app)
 
 # --- Fixture for Test Data Setup & Teardown ---


### PR DESCRIPTION
## Summary
- align RewardService with UTC handling
- isolate DB override for reward tests to avoid cross-test contamination

## Testing
- `venv/bin/python -m pytest tests/test_rewards.py tests/test_reward_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68462e3501288329ac53b9b3b5790806