### PR TITLE
Add dedicated game services with tests

### DIFF
--- a/cc-webapp/backend/app/services/__init__.py
+++ b/cc-webapp/backend/app/services/__init__.py
@@ -2,6 +2,9 @@ from .reward_service import RewardService
 from .notification_service import NotificationService  # Added
 from .tracking_service import TrackingService  # Added
 from .game_service import GameService
+from .slot_service import SlotService
+from .roulette_service import RouletteService
+from .gacha_service import GachaService
 
 # Optionally, make other services available for easier import if structured this way
 # from .user_service import UserService
@@ -25,6 +28,9 @@ __all__ = [
     "NotificationService", # Added
     "TrackingService", # Added
     "GameService",
+    "SlotService",
+    "RouletteService",
+    "GachaService",
     # "UserService",
     # "AuthService",
     # "TokenService",

--- a/cc-webapp/backend/app/services/gacha_service.py
+++ b/cc-webapp/backend/app/services/gacha_service.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+from typing import List
+from sqlalchemy.orm import Session
+import random
+
+from .token_service import deduct_tokens, get_balance
+from ..repositories.game_repository import GameRepository
+
+
+@dataclass
+class GachaPullResult:
+    results: List[str]
+    tokens_change: int
+    balance: int
+
+
+class GachaService:
+    """가챠 뽑기 로직을 담당하는 서비스."""
+
+    def __init__(self, repository: GameRepository | None = None) -> None:
+        self.repo = repository or GameRepository()
+
+    def pull(self, user_id: int, count: int, db: Session) -> GachaPullResult:
+        """가챠 뽑기를 수행."""
+        pulls = 10 if count >= 10 else 1
+        cost = 450 if pulls == 10 else 50
+        deduct_tokens(user_id, cost, db)
+
+        results: List[str] = []
+        current_count = self.repo.get_gacha_count(user_id)
+        history = self.repo.get_gacha_history(user_id)
+
+        rarity_table = [
+            ("Legendary", 0.005),
+            ("Epic", 0.045),
+            ("Rare", 0.25),
+            ("Common", 0.70),
+        ]
+
+        for _ in range(pulls):
+            current_count += 1
+            pity = current_count >= 90
+            rnd = random.random()
+            cumulative = 0.0
+            rarity = "Common"
+            for name, prob in rarity_table:
+                adj_prob = prob
+                if history and name in history:
+                    adj_prob *= 0.5
+                cumulative += adj_prob
+                if rnd <= cumulative:
+                    rarity = name
+                    break
+            if pity and rarity not in {"Epic", "Legendary"}:
+                rarity = "Epic"
+                current_count = 0
+            results.append(rarity)
+            history.insert(0, rarity)
+            history = history[:10]
+
+        self.repo.set_gacha_count(user_id, current_count)
+        self.repo.set_gacha_history(user_id, history)
+
+        balance = get_balance(user_id, db)
+        self.repo.record_action(db, user_id, "GACHA_PULL", -cost)
+        return GachaPullResult(results, -cost, balance)

--- a/cc-webapp/backend/app/services/game_service.py
+++ b/cc-webapp/backend/app/services/game_service.py
@@ -1,157 +1,40 @@
-import random
-from typing import List, Optional
+from typing import Optional
+
 from sqlalchemy.orm import Session
 
-from .token_service import deduct_tokens, add_tokens, get_balance
 from ..repositories.game_repository import GameRepository
-from .. import models
 
-class SlotSpinResult:
-    def __init__(self, result: str, reward: int, balance: int, streak: int, animation: Optional[str]):
-        self.result = result
-        self.tokens_change = reward - 2
-        self.balance = balance
-        self.streak = streak
-        self.animation = animation
-
-
-class RouletteSpinResult:
-    def __init__(self, number: int, result: str, payout: int, balance: int, animation: Optional[str]):
-        self.winning_number = number
-        self.result = result
-        self.tokens_change = payout
-        self.balance = balance
-        self.animation = animation
-
-
-class GachaPullResult:
-    def __init__(self, results: List[str], balance: int, cost: int):
-        self.results = results
-        self.tokens_change = -cost
-        self.balance = balance
+from .slot_service import SlotService, SlotSpinResult
+from .roulette_service import RouletteService, RouletteSpinResult
+from .gacha_service import GachaService, GachaPullResult
 
 
 class GameService:
-    def __init__(self, repository: GameRepository | None = None):
+    """각 게임별 서비스 클래스를 조합해 제공하는 파사드."""
+
+    def __init__(self, repository: "GameRepository | None" = None):
         self.repo = repository or GameRepository()
+        self.slot_service = SlotService(self.repo)
+        self.roulette_service = RouletteService(self.repo)
+        self.gacha_service = GachaService(self.repo)
+
 
     def slot_spin(self, user_id: int, db: Session) -> SlotSpinResult:
-        deduct_tokens(user_id, 2, db)
+        """슬롯 게임 스핀을 실행."""
+        return self.slot_service.spin(user_id, db)
 
-        segment = self.repo.get_user_segment(db, user_id)
-        streak = self.repo.get_streak(user_id)
-
-        win_prob = 0.10 + min(streak * 0.01, 0.05)
-        if segment == "Whale":
-            win_prob += 0.02
-        elif segment == "Low":
-            win_prob -= 0.02
-        jackpot_prob = 0.01
-
-        spin = random.random()
-        result = "lose"
-        reward = 0
-        animation = "lose"
-        if streak >= 7:
-            result = "win"
-            reward = 10
-            animation = "force_win"
-            streak = 0
-        elif spin < jackpot_prob:
-            result = "jackpot"
-            reward = 100
-            animation = "jackpot"
-            streak = 0
-        elif spin < jackpot_prob + win_prob:
-            result = "win"
-            reward = 10
-            animation = "win"
-            streak = 0
-        else:
-            streak += 1
-
-        if reward:
-            add_tokens(user_id, reward, db)
-
-        self.repo.set_streak(user_id, streak)
-        balance = get_balance(user_id, db)
-        self.repo.record_action(db, user_id, "SLOT_SPIN", -2)
-        return SlotSpinResult(result, reward, balance, streak, animation)
-
-    def roulette_spin(self, user_id: int, bet: int, bet_type: str, value: Optional[str], db: Session) -> RouletteSpinResult:
-        bet = max(1, min(bet, 50))
-        deduct_tokens(user_id, bet, db)
-
-        segment = self.repo.get_user_segment(db, user_id)
-        edge_map = {"Whale": 0.05, "Medium": 0.10, "Low": 0.15}
-        house_edge = edge_map.get(segment, 0.10)
-
-        number = random.randint(0, 36)
-        payout = 0
-        result = "lose"
-        animation = "lose"
-
-        if bet_type == "number" and value is not None:
-            if number == int(value):
-                payout = int(bet * 35 * (1 - house_edge))
-        elif bet_type == "color" and value in {"red", "black"}:
-            color_map = {"red": set(range(1, 37, 2)), "black": set(range(2, 37, 2))}
-            if number != 0 and number in color_map[value]:
-                payout = int(bet * (1 - house_edge))
-        elif bet_type == "odd_even" and value in {"odd", "even"}:
-            if number != 0 and (number % 2 == 0) == (value == "even"):
-                payout = int(bet * (1 - house_edge))
-
-        if payout:
-            result = "win"
-            animation = "win"
-            add_tokens(user_id, payout, db)
-
-        balance = get_balance(user_id, db)
-        self.repo.record_action(db, user_id, "ROULETTE_SPIN", -bet)
-        return RouletteSpinResult(number, result, payout - bet, balance, animation)
+    def roulette_spin(
+        self,
+        user_id: int,
+        bet: int,
+        bet_type: str,
+        value: Optional[str],
+        db: Session,
+    ) -> RouletteSpinResult:
+        """룰렛 게임 스핀 실행."""
+        return self.roulette_service.spin(user_id, bet, bet_type, value, db)
 
     def gacha_pull(self, user_id: int, count: int, db: Session) -> GachaPullResult:
-        pulls = 10 if count >= 10 else 1
-        cost = 450 if pulls == 10 else 50
-        deduct_tokens(user_id, cost, db)
-
-        results: List[str] = []
-        current_count = self.repo.get_gacha_count(user_id)
-        history = self.repo.get_gacha_history(user_id)
-
-        rarity_table = [
-            ("Legendary", 0.005),
-            ("Epic", 0.045),
-            ("Rare", 0.25),
-            ("Common", 0.70),
-        ]
-
-        for _ in range(pulls):
-            current_count += 1
-            pity = current_count >= 90
-            rnd = random.random()
-            cumulative = 0.0
-            rarity = "Common"
-            for name, prob in rarity_table:
-                adj_prob = prob
-                if history and name in history:
-                    adj_prob *= 0.5
-                cumulative += adj_prob
-                if rnd <= cumulative:
-                    rarity = name
-                    break
-            if pity and rarity not in {"Epic", "Legendary"}:
-                rarity = "Epic"
-                current_count = 0
-            results.append(rarity)
-            history.insert(0, rarity)
-            history = history[:10]
-
-        self.repo.set_gacha_count(user_id, current_count)
-        self.repo.set_gacha_history(user_id, history)
-
-        balance = get_balance(user_id, db)
-        self.repo.record_action(db, user_id, "GACHA_PULL", -cost)
-        return GachaPullResult(results, balance, cost)
+        """가챠 뽑기 실행."""
+        return self.gacha_service.pull(user_id, count, db)
 

--- a/cc-webapp/backend/app/services/roulette_service.py
+++ b/cc-webapp/backend/app/services/roulette_service.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass
+from typing import Optional
+from sqlalchemy.orm import Session
+import random
+
+from .token_service import deduct_tokens, add_tokens, get_balance
+from ..repositories.game_repository import GameRepository
+
+
+@dataclass
+class RouletteSpinResult:
+    winning_number: int
+    result: str
+    tokens_change: int
+    balance: int
+    animation: Optional[str]
+
+
+class RouletteService:
+    """룰렛 게임 로직을 담당하는 서비스."""
+
+    def __init__(self, repository: GameRepository | None = None) -> None:
+        self.repo = repository or GameRepository()
+
+    def spin(self, user_id: int, bet: int, bet_type: str, value: Optional[str], db: Session) -> RouletteSpinResult:
+        """룰렛 스핀 실행."""
+        bet = max(1, min(bet, 50))
+        deduct_tokens(user_id, bet, db)
+
+        segment = self.repo.get_user_segment(db, user_id)
+        edge_map = {"Whale": 0.05, "Medium": 0.10, "Low": 0.15}
+        house_edge = edge_map.get(segment, 0.10)
+
+        number = random.randint(0, 36)
+        payout = 0
+        result = "lose"
+        animation = "lose"
+
+        if bet_type == "number" and value is not None:
+            if number == int(value):
+                payout = int(bet * 35 * (1 - house_edge))
+        elif bet_type == "color" and value in {"red", "black"}:
+            color_map = {"red": set(range(1, 37, 2)), "black": set(range(2, 37, 2))}
+            if number != 0 and number in color_map[value]:
+                payout = int(bet * (1 - house_edge))
+        elif bet_type == "odd_even" and value in {"odd", "even"}:
+            if number != 0 and (number % 2 == 0) == (value == "even"):
+                payout = int(bet * (1 - house_edge))
+
+        if payout:
+            result = "win"
+            animation = "win"
+            add_tokens(user_id, payout, db)
+
+        balance = get_balance(user_id, db)
+        self.repo.record_action(db, user_id, "ROULETTE_SPIN", -bet)
+        return RouletteSpinResult(number, result, payout - bet, balance, animation)

--- a/cc-webapp/backend/app/services/slot_service.py
+++ b/cc-webapp/backend/app/services/slot_service.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from typing import Optional
+from sqlalchemy.orm import Session
+import random
+
+from .token_service import deduct_tokens, add_tokens, get_balance
+from ..repositories.game_repository import GameRepository
+
+
+@dataclass
+class SlotSpinResult:
+    result: str
+    tokens_change: int
+    balance: int
+    streak: int
+    animation: Optional[str]
+
+
+class SlotService:
+    """슬롯 머신 로직을 담당하는 서비스 계층."""
+
+    def __init__(self, repository: GameRepository | None = None) -> None:
+        self.repo = repository or GameRepository()
+
+    def spin(self, user_id: int, db: Session) -> SlotSpinResult:
+        """슬롯 스핀을 실행하고 결과를 반환."""
+        # 토큰 차감. 부족하면 ValueError 발생
+        deduct_tokens(user_id, 2, db)
+
+        segment = self.repo.get_user_segment(db, user_id)
+        streak = self.repo.get_streak(user_id)
+
+        # 기본 승리 확률과 잭팟 확률 설정
+        win_prob = 0.10 + min(streak * 0.01, 0.05)
+        if segment == "Whale":
+            win_prob += 0.02
+        elif segment == "Low":
+            win_prob -= 0.02
+        jackpot_prob = 0.01
+
+        spin = random.random()
+        result = "lose"
+        reward = 0
+        animation = "lose"
+        if streak >= 7:
+            # 연패 보상으로 강제 승리
+            result = "win"
+            reward = 10
+            animation = "force_win"
+            streak = 0
+        elif spin < jackpot_prob:
+            result = "jackpot"
+            reward = 100
+            animation = "jackpot"
+            streak = 0
+        elif spin < jackpot_prob + win_prob:
+            result = "win"
+            reward = 10
+            animation = "win"
+            streak = 0
+        else:
+            streak += 1
+
+        if reward:
+            add_tokens(user_id, reward, db)
+
+        self.repo.set_streak(user_id, streak)
+        balance = get_balance(user_id, db)
+        self.repo.record_action(db, user_id, "SLOT_SPIN", -2)
+        return SlotSpinResult(result, reward - 2, balance, streak, animation)

--- a/cc-webapp/backend/tests/test_gacha_service.py
+++ b/cc-webapp/backend/tests/test_gacha_service.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.orm import Session
+
+from app.services.gacha_service import GachaService, GachaPullResult
+from app.repositories.game_repository import GameRepository
+
+
+class TestGachaService(unittest.TestCase):
+    def setUp(self):
+        self.mock_db = MagicMock(spec=Session)
+        self.repo = MagicMock(spec=GameRepository)
+        self.service = GachaService(repository=self.repo)
+
+    @patch("app.services.gacha_service.deduct_tokens")
+    @patch("app.services.gacha_service.get_balance", return_value=80)
+    @patch("app.services.gacha_service.random.random", return_value=0.001)
+    def test_pull_legendary(self, m_rand, m_balance, m_deduct):
+        self.repo.get_gacha_count.return_value = 0
+        self.repo.get_gacha_history.return_value = []
+
+        result = self.service.pull(1, 1, self.mock_db)
+
+        self.assertIsInstance(result, GachaPullResult)
+        self.assertIn(result.results[0], {"Legendary", "Epic", "Rare", "Common"})
+        self.repo.record_action.assert_called_once()
+
+    @patch("app.services.gacha_service.deduct_tokens", side_effect=ValueError)
+    def test_pull_insufficient_tokens(self, m_deduct):
+        with self.assertRaises(ValueError):
+            self.service.pull(1, 1, self.mock_db)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cc-webapp/backend/tests/test_roulette_service.py
+++ b/cc-webapp/backend/tests/test_roulette_service.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.orm import Session
+
+from app.services.roulette_service import RouletteService, RouletteSpinResult
+from app.repositories.game_repository import GameRepository
+
+
+class TestRouletteService(unittest.TestCase):
+    def setUp(self):
+        self.mock_db = MagicMock(spec=Session)
+        self.repo = MagicMock(spec=GameRepository)
+        self.service = RouletteService(repository=self.repo)
+
+    @patch("app.services.roulette_service.deduct_tokens")
+    @patch("app.services.roulette_service.add_tokens")
+    @patch("app.services.roulette_service.get_balance", return_value=150)
+    @patch("app.services.roulette_service.random.randint", return_value=7)
+    def test_spin_win_number(self, m_rand, m_balance, m_add, m_deduct):
+        self.repo.get_user_segment.return_value = "Medium"
+        result = self.service.spin(1, 10, "number", "7", self.mock_db)
+
+        self.assertIsInstance(result, RouletteSpinResult)
+        self.assertEqual(result.result, "win")
+        self.assertGreater(result.tokens_change, -10)
+        m_add.assert_called_once()
+
+    @patch("app.services.roulette_service.deduct_tokens", side_effect=ValueError)
+    def test_spin_insufficient_tokens(self, m_deduct):
+        with self.assertRaises(ValueError):
+            self.service.spin(1, 5, "color", "red", self.mock_db)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cc-webapp/backend/tests/test_slot_service.py
+++ b/cc-webapp/backend/tests/test_slot_service.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.orm import Session
+
+from app.services.slot_service import SlotService, SlotSpinResult
+from app.repositories.game_repository import GameRepository
+
+
+class TestSlotService(unittest.TestCase):
+    def setUp(self):
+        self.mock_db = MagicMock(spec=Session)
+        self.repo = MagicMock(spec=GameRepository)
+        self.service = SlotService(repository=self.repo)
+
+    @patch("app.services.slot_service.deduct_tokens")
+    @patch("app.services.slot_service.add_tokens")
+    @patch("app.services.slot_service.get_balance", return_value=100)
+    @patch("app.services.slot_service.random.random", return_value=0.99)
+    def test_spin_lose(self, m_rand, m_balance, m_add, m_deduct):
+        self.repo.get_user_segment.return_value = "Low"
+        self.repo.get_streak.return_value = 0
+
+        result = self.service.spin(1, self.mock_db)
+
+        self.assertIsInstance(result, SlotSpinResult)
+        self.assertEqual(result.result, "lose")
+        self.assertEqual(result.tokens_change, -2)
+        self.repo.set_streak.assert_called_once_with(1, 1)
+        self.repo.record_action.assert_called_once()
+
+    @patch("app.services.slot_service.deduct_tokens")
+    @patch("app.services.slot_service.add_tokens")
+    @patch("app.services.slot_service.get_balance", return_value=120)
+    @patch("app.services.slot_service.random.random", return_value=0.0)
+    def test_spin_jackpot(self, m_rand, m_balance, m_add, m_deduct):
+        self.repo.get_user_segment.return_value = "Medium"
+        self.repo.get_streak.return_value = 0
+
+        result = self.service.spin(1, self.mock_db)
+
+        self.assertEqual(result.result, "jackpot")
+        self.assertEqual(result.tokens_change, 98)
+        m_add.assert_called_once_with(1, 100, self.mock_db)
+
+    @patch("app.services.slot_service.deduct_tokens", side_effect=ValueError)
+    def test_spin_insufficient_tokens(self, m_deduct):
+        with self.assertRaises(ValueError):
+            self.service.spin(1, self.mock_db)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create separate SlotService, RouletteService, and GachaService modules
- update GameService to delegate to new modules
- expose new services in `services/__init__.py`
- add unit tests for each game service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846409c902083298056b847d1038277