### PR TITLE
Improve gacha configuration and add logging

### DIFF
--- a/cc-webapp/backend/app/routers/auth.py
+++ b/cc-webapp/backend/app/routers/auth.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import os
 from fastapi import APIRouter, Depends, HTTPException, status
+import logging
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
@@ -21,6 +22,8 @@ JWT_EXPIRE_MINUTES = int(os.getenv("JWT_EXPIRE_MINUTES", "60"))
 INITIAL_CYBER_TOKENS = int(os.getenv("INITIAL_CYBER_TOKENS", "200"))
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+logger = logging.getLogger(__name__)
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
@@ -56,13 +59,19 @@ class UserMe(BaseModel):
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    """JWT 액세스 토큰 생성"""
     to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=JWT_EXPIRE_MINUTES))
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=JWT_EXPIRE_MINUTES)
+    )
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+    token = jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+    logger.debug("Access token created for %s", data.get("sub"))
+    return token
 
 
 def get_user_from_token(token: str = Depends(oauth2_scheme)):
+    """토큰에서 사용자 ID 추출"""
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
@@ -78,16 +87,28 @@ def get_user_from_token(token: str = Depends(oauth2_scheme)):
 
 @router.post("/verify-invite")
 async def verify_invite(req: VerifyInviteRequest, db: Session = Depends(get_db)):
-    code = db.query(models.InviteCode).filter(models.InviteCode.code == req.code, models.InviteCode.is_used == False).first()
-    return {"valid": bool(code)}
+    """초대 코드 검증 엔드포인트"""
+    code = db.query(models.InviteCode).filter(
+        models.InviteCode.code == req.code,
+        models.InviteCode.is_used == False
+    ).first()
+    is_valid = bool(code)
+    logger.info("Invite code %s validity: %s", req.code, is_valid)
+    return {"valid": is_valid}
 
 
 @router.post("/signup", response_model=TokenResponse)
 async def signup(data: SignUpRequest, db: Session = Depends(get_db)):
+    """회원 가입 처리"""
     if db.query(models.User).filter(models.User.nickname == data.nickname).first():
+        logger.warning("Signup failed: nickname %s already taken", data.nickname)
         raise HTTPException(status_code=400, detail="Nickname already taken")
-    invite = db.query(models.InviteCode).filter(models.InviteCode.code == data.invite_code, models.InviteCode.is_used == False).first()
+    invite = db.query(models.InviteCode).filter(
+        models.InviteCode.code == data.invite_code,
+        models.InviteCode.is_used == False
+    ).first()
     if not invite:
+        logger.warning("Signup failed: invalid invite code %s", data.invite_code)
         raise HTTPException(status_code=400, detail="Invalid invite code")
     hashed_password = pwd_context.hash(data.password)
     user = models.User(nickname=data.nickname, password_hash=hashed_password, invite_code=data.invite_code)
@@ -97,27 +118,35 @@ async def signup(data: SignUpRequest, db: Session = Depends(get_db)):
     db.refresh(user)
     token_service.add_tokens(user.id, INITIAL_CYBER_TOKENS)  # 표준화된 초기 토큰 값 사용
     access_token = create_access_token({"sub": str(user.id)})
+    logger.info("Signup success for nickname %s", data.nickname)
     return TokenResponse(access_token=access_token)
 
 
 @router.post("/login", response_model=TokenResponse)
 async def login(data: LoginRequest, db: Session = Depends(get_db)):
+    """로그인 처리"""
     # Shortcut path used in tests without database setup
     if data.nickname == "testuser" and data.password == "password":
+        logger.info("Test login for %s", data.nickname)
         return TokenResponse(access_token="fake-token")
 
     user = db.query(models.User).filter(models.User.nickname == data.nickname).first()
     if not user or not pwd_context.verify(data.password, user.password_hash):
+        logger.warning("Login failed for nickname %s", data.nickname)
         raise HTTPException(status_code=401, detail="Invalid credentials")
     access_token = create_access_token({"sub": str(user.id)})
+    logger.info("Login success for nickname %s", data.nickname)
     return TokenResponse(access_token=access_token)
 
 
 @router.get("/me", response_model=UserMe)
 async def get_me(user_id: int = Depends(get_user_from_token), db: Session = Depends(get_db)):
+    """현재 로그인한 사용자 정보 반환"""
     user = db.query(models.User).filter(models.User.id == user_id).first()
     if not user:
+        logger.warning("User info requested for missing id %s", user_id)
         raise HTTPException(status_code=404, detail="User not found")
+    logger.info("User info retrieved for id %s", user_id)
     return user
 
 

--- a/cc-webapp/backend/app/routers/gacha.py
+++ b/cc-webapp/backend/app/routers/gacha.py
@@ -1,11 +1,11 @@
 # cc-webapp/backend/app/routers/gacha.py
-from fastapi import APIRouter, Depends, HTTPException, Body
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from typing import Dict, Any, Union # Union for Pydantic model
+from typing import Dict, Any, Union
 import logging
 
 # Assuming these utilities and models are correctly structured
-from ..utils.reward_utils import spin_gacha
+from ..services.gacha_service import GachaService
 from ..models import User # To verify user exists
 from ..database import get_db # Original get_db from database.py
 from pydantic import BaseModel
@@ -13,11 +13,25 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
+
+def get_service() -> GachaService:
+    """가챠 서비스 의존성"""
+    return GachaService()
+
+
+class GachaConfig(BaseModel):
+    rarity_table: list[tuple[str, float]]
+    reward_pool: Dict[str, int]
+
 # --- Pydantic Models ---
 class GachaPullRequest(BaseModel):
+    """가챠 뽑기 요청"""
+
     user_id: int
 
 class GachaPullResponseItem(BaseModel):
+    """가챠 결과 응답"""
+
     type: str
     amount: Union[int, None] = None      # For COIN type
     stage: Union[int, None] = None       # For CONTENT_UNLOCK type
@@ -37,7 +51,8 @@ class GachaPullResponseItem(BaseModel):
 @router.post("/gacha/pull", response_model=GachaPullResponseItem, tags=["gacha"])
 async def pull_gacha_for_user(
     request_data: GachaPullRequest,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    service: GachaService = Depends(get_service),
 ):
     """
     Allows a user to pull the gacha.
@@ -56,21 +71,16 @@ async def pull_gacha_for_user(
         logger.warning(f"Gacha pull attempt by non-existent user_id: {request_data.user_id}")
         raise HTTPException(status_code=404, detail=f"User with id {request_data.user_id} not found.")
 
-    # TODO: Implement currency deduction logic here if applicable.
-    # Example:
-    # if not user_has_enough_currency(user, GACHA_COST):
-    #     raise HTTPException(status_code=402, detail="Insufficient currency for gacha pull.")
-    # deduct_currency(user, GACHA_COST, db)
-
-    # Call the gacha logic from reward_utils.py
-    # spin_gacha is expected to return a dictionary like:
-    # {"type": "COIN", "amount": N, "message": "..."}
-    # {"type": "CONTENT_UNLOCK", "stage": S, "message": "..."}
-    # {"type": "BADGE", "badge_name": B, "message": "..."}
-    gacha_result_dict = spin_gacha(user_id=request_data.user_id, db=db)
+    # GachaService가 통화 차감 및 보상 풀 관리 등을 수행
+    result = service.pull(request_data.user_id, 1, db)
+    gacha_result_dict = {"type": result.results[0]}
 
     if not gacha_result_dict or not gacha_result_dict.get("type"):
-        logger.error(f"spin_gacha function returned an invalid result for user_id {request_data.user_id}: {gacha_result_dict}")
+        logger.error(
+            "GachaService returned an invalid result for user_id %s: %s",
+            request_data.user_id,
+            gacha_result_dict,
+        )
         # This case should ideally not happen if spin_gacha is robust and always returns a dict with a type
         raise HTTPException(status_code=500, detail="Gacha spin failed to produce a valid result. Please try again.")
 
@@ -82,3 +92,19 @@ async def pull_gacha_for_user(
     # If it's missing required fields (like 'type'), Pydantic will raise a validation error
     # which FastAPI handles as a 422 Unprocessable Entity, but our check above should catch missing 'type'.
     return GachaPullResponseItem(**gacha_result_dict)
+
+
+@router.get("/gacha/config", response_model=GachaConfig, tags=["gacha"])
+async def get_gacha_config(service: GachaService = Depends(get_service)):
+    """현재 가챠 설정 조회"""
+    return GachaConfig(**service.get_config())
+
+
+@router.put("/gacha/config", response_model=GachaConfig, tags=["gacha"])
+async def update_gacha_config(
+    config: GachaConfig,
+    service: GachaService = Depends(get_service),
+):
+    """가챠 설정 갱신"""
+    service.update_config(rarity_table=config.rarity_table, reward_pool=config.reward_pool)
+    return GachaConfig(**service.get_config())

--- a/cc-webapp/backend/app/services/gacha_service.py
+++ b/cc-webapp/backend/app/services/gacha_service.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Dict, Tuple
 from sqlalchemy.orm import Session
 import random
+import os
+import json
+import logging
 
 from .token_service import deduct_tokens, get_balance
 from ..repositories.game_repository import GameRepository
@@ -15,27 +18,70 @@ class GachaPullResult:
 
 
 class GachaService:
-    """가챠 뽑기 로직을 담당하는 서비스."""
+    """가챠 뽑기 로직을 담당하는 서비스.
+
+    확률 테이블과 보상 풀은 환경 변수에서 로드되며, 런타임에 갱신할 수 있습니다.
+    """
+
+    DEFAULT_RARITY_TABLE: list[tuple[str, float]] = [
+        ("Legendary", 0.005),
+        ("Epic", 0.045),
+        ("Rare", 0.25),
+        ("Common", 0.70),
+    ]
 
     def __init__(self, repository: GameRepository | None = None) -> None:
         self.repo = repository or GameRepository()
+        self.logger = logging.getLogger(__name__)
+        self.rarity_table = self._load_rarity_table()
+        self.reward_pool = self._load_reward_pool()
+
+    def _load_rarity_table(self) -> List[Tuple[str, float]]:
+        """환경 변수에서 확률 테이블을 로드"""
+        table_json = os.getenv("GACHA_RARITY_TABLE")
+        if table_json:
+            try:
+                data = json.loads(table_json)
+                return [(str(name), float(prob)) for name, prob in data]
+            except Exception as e:  # noqa: BLE001
+                self.logger.error("Invalid GACHA_RARITY_TABLE: %s", e)
+        return self.DEFAULT_RARITY_TABLE.copy()
+
+    def _load_reward_pool(self) -> Dict[str, int]:
+        """환경 변수에서 보상 풀 정보를 로드"""
+        pool_json = os.getenv("GACHA_REWARD_POOL")
+        if pool_json:
+            try:
+                data = json.loads(pool_json)
+                return {str(k): int(v) for k, v in data.items()}
+            except Exception as e:  # noqa: BLE001
+                self.logger.error("Invalid GACHA_REWARD_POOL: %s", e)
+        # 기본 풀은 무한으로 간주
+        return {}
+
+    def get_config(self) -> dict:
+        """현재 설정 정보를 반환"""
+        return {"rarity_table": self.rarity_table, "reward_pool": self.reward_pool}
+
+    def update_config(self, *, rarity_table: List[Tuple[str, float]] | None = None, reward_pool: Dict[str, int] | None = None) -> None:
+        """확률 테이블 및 보상 풀을 업데이트"""
+        if rarity_table is not None:
+            self.rarity_table = rarity_table
+        if reward_pool is not None:
+            self.reward_pool = reward_pool
 
     def pull(self, user_id: int, count: int, db: Session) -> GachaPullResult:
         """가챠 뽑기를 수행."""
         pulls = 10 if count >= 10 else 1
         cost = 450 if pulls == 10 else 50
+        self.logger.info("Deducting %s tokens from user %s", cost, user_id)
         deduct_tokens(user_id, cost, db)
 
         results: List[str] = []
         current_count = self.repo.get_gacha_count(user_id)
         history = self.repo.get_gacha_history(user_id)
 
-        rarity_table = [
-            ("Legendary", 0.005),
-            ("Epic", 0.045),
-            ("Rare", 0.25),
-            ("Common", 0.70),
-        ]
+        rarity_table = self.rarity_table
 
         for _ in range(pulls):
             current_count += 1
@@ -54,6 +100,12 @@ class GachaService:
             if pity and rarity not in {"Epic", "Legendary"}:
                 rarity = "Epic"
                 current_count = 0
+            if self.reward_pool:
+                available = self.reward_pool.get(rarity, 0)
+                if available <= 0:
+                    rarity = "Common"
+                else:
+                    self.reward_pool[rarity] = available - 1
             results.append(rarity)
             history.insert(0, rarity)
             history = history[:10]
@@ -63,4 +115,7 @@ class GachaService:
 
         balance = get_balance(user_id, db)
         self.repo.record_action(db, user_id, "GACHA_PULL", -cost)
+        self.logger.debug(
+            "User %s gacha results %s, balance %s", user_id, results, balance
+        )
         return GachaPullResult(results, -cost, balance)

--- a/cc-webapp/backend/tests/test_auth_logging.py
+++ b/cc-webapp/backend/tests/test_auth_logging.py
@@ -1,0 +1,17 @@
+"""Auth 라우터의 로깅을 검증하는 테스트."""
+
+import logging
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_login_logging(caplog):
+    """로그인 성공 시 INFO 로그가 남는지 확인."""
+    with caplog.at_level(logging.INFO):
+        response = client.post(
+            "/api/auth/login",
+            json={"nickname": "testuser", "password": "password"},
+        )
+        assert response.status_code == 200
+        assert "Test login for testuser" in caplog.text

--- a/cc-webapp/backend/tests/test_gacha_router.py
+++ b/cc-webapp/backend/tests/test_gacha_router.py
@@ -1,0 +1,42 @@
+"""가챠 라우터 테스트 모듈."""
+
+from unittest.mock import MagicMock
+from fastapi.testclient import TestClient
+from app.main import app
+from app.services.gacha_service import GachaPullResult
+from app.routers import gacha as gacha_router
+
+
+client = TestClient(app)
+
+
+def test_pull_gacha_uses_service(monkeypatch):
+    """서비스 의존성 주입이 제대로 동작하는지 확인."""
+
+    service_mock = MagicMock()
+    service_mock.pull.return_value = GachaPullResult(["Legendary"], -50, 50)
+    monkeypatch.setitem(
+        client.app.dependency_overrides, gacha_router.get_service, lambda: service_mock
+    )
+
+    class DummyDB:
+        def query(self, model):
+            class Q:
+                def filter(self, *args, **kwargs):
+                    class F:
+                        def first(self):
+                            return object()
+
+                    return F()
+
+            return Q()
+
+    monkeypatch.setitem(
+        client.app.dependency_overrides, gacha_router.get_db, lambda: DummyDB()
+    )
+
+    response = client.post("/api/gacha/pull", json={"user_id": 1})
+    assert response.status_code == 200
+    assert response.json()["type"] == "Legendary"
+    service_mock.pull.assert_called_once()
+

--- a/cc-webapp/backend/tests/test_gacha_service_config.py
+++ b/cc-webapp/backend/tests/test_gacha_service_config.py
@@ -1,0 +1,34 @@
+"""GachaService 설정 관련 테스트."""
+
+import json
+from unittest.mock import MagicMock, patch
+from sqlalchemy.orm import Session
+from app.services.gacha_service import GachaService, GachaPullResult
+from app.repositories.game_repository import GameRepository
+
+
+def test_load_rarity_table_from_env(monkeypatch):
+    """환경 변수에서 확률 테이블을 로드하는지 검증."""
+    table = [["Legendary", 1.0]]
+    monkeypatch.setenv("GACHA_RARITY_TABLE", json.dumps(table))
+    service = GachaService(repository=MagicMock(spec=GameRepository))
+    assert service.rarity_table == [("Legendary", 1.0)]
+
+
+def test_reward_pool(monkeypatch):
+    """보상 풀이 소진되면 Common으로 대체되는지 확인."""
+    monkeypatch.setenv("GACHA_RARITY_TABLE", json.dumps([["Legendary", 1.0]]))
+    monkeypatch.setenv("GACHA_REWARD_POOL", json.dumps({"Legendary": 1}))
+    repo = MagicMock(spec=GameRepository)
+    repo.get_gacha_count.return_value = 0
+    repo.get_gacha_history.return_value = []
+    service = GachaService(repository=repo)
+    with patch("app.services.gacha_service.deduct_tokens"), patch(
+        "app.services.gacha_service.get_balance", return_value=0
+    ):
+        result1 = service.pull(1, 1, MagicMock(spec=Session))
+        result2 = service.pull(1, 1, MagicMock(spec=Session))
+    assert result1.results[0] == "Legendary"
+    assert result2.results[0] == "Common"
+
+


### PR DESCRIPTION
## Summary
- enhance auth router logging
- add environment-configurable rarity table and reward pool to GachaService
- support configuration management endpoints in gacha router
- deduct tokens via GachaService and log results
- add tests for logging and gacha configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464d29dbac8329943d584a3c8f3380