### PR TITLE
Add env-based segment config

### DIFF
--- a/cc-webapp/backend/README.md
+++ b/cc-webapp/backend/README.md
@@ -46,6 +46,7 @@ This method is suitable for developing and testing the backend in isolation.
     *   Set up environment variables:
         *   Copy `.env.example` to `.env` within the `cc-webapp/backend` directory.
         *   Update variables in this `.env` file to point to your manually managed PostgreSQL, Redis, and Kafka instances.
+        *   `SEGMENT_PROB_ADJUST_JSON` 및 `HOUSE_EDGE_JSON` 값을 지정하여 사용자 세그먼트별 확률 조정과 하우스 엣지를 설정할 수 있습니다.
     *   Apply database migrations manually:
         ```bash
         alembic upgrade head

--- a/cc-webapp/backend/app/services/user_segment_service.py
+++ b/cc-webapp/backend/app/services/user_segment_service.py
@@ -1,24 +1,49 @@
+import json
+import logging
+import os
 from sqlalchemy.orm import Session
 
 from app import models
 
+logger = logging.getLogger(__name__)
+
 class UserSegmentService:
     """Service for retrieving user segment and adjusting game probabilities."""
 
-    SEGMENT_PROB_ADJUST = {
+    DEFAULT_SEGMENT_PROB_ADJUST = {
         "Whale": 0.02,
         "Low": -0.02,
         "Medium": 0.0,
     }
 
-    HOUSE_EDGE = {
+    DEFAULT_HOUSE_EDGE = {
         "Whale": 0.05,
         "Medium": 0.10,
         "Low": 0.15,
     }
 
     def __init__(self, db: Session) -> None:
+        """서비스 초기화. 환경 변수에서 설정을 로드한다."""
         self.db = db
+        self.SEGMENT_PROB_ADJUST = self._load_json_env(
+            "SEGMENT_PROB_ADJUST_JSON", self.DEFAULT_SEGMENT_PROB_ADJUST
+        )
+        self.HOUSE_EDGE = self._load_json_env(
+            "HOUSE_EDGE_JSON", self.DEFAULT_HOUSE_EDGE
+        )
+
+    def _load_json_env(self, name: str, default: dict) -> dict:
+        """환경 변수에서 JSON 구성을 읽어 들인다."""
+        value = os.getenv(name)
+        if not value:
+            return default
+        try:
+            data = json.loads(value)
+            if isinstance(data, dict):
+                return {k: float(v) for k, v in data.items()}
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.warning("%s 파싱 실패: %s", name, e)
+        return default
 
     def get_segment_label(self, user_id: int) -> str:
         seg = (

--- a/cc-webapp/backend/tests/test_user_segment_service.py
+++ b/cc-webapp/backend/tests/test_user_segment_service.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
+import os
 
 from app.services.user_segment_service import UserSegmentService
 from app.models import UserSegment
@@ -28,6 +29,25 @@ class TestUserSegmentService(unittest.TestCase):
         self.assertEqual(self.service.get_house_edge("Whale"), 0.05)
         self.assertEqual(self.service.get_house_edge("Low"), 0.15)
         self.assertEqual(self.service.get_house_edge("Other"), 0.10)
+
+
+class TestUserSegmentServiceEnv(unittest.TestCase):
+    """환경 변수 적용 여부 테스트"""
+
+    def setUp(self):
+        self.mock_db = MagicMock()
+
+    def tearDown(self):
+        os.environ.pop("SEGMENT_PROB_ADJUST_JSON", None)
+        os.environ.pop("HOUSE_EDGE_JSON", None)
+
+    def test_env_overrides_defaults(self):
+        os.environ["SEGMENT_PROB_ADJUST_JSON"] = '{"Whale": 0.5}'
+        os.environ["HOUSE_EDGE_JSON"] = '{"Whale": 0.2}'
+        service = UserSegmentService(db=self.mock_db)
+        self.assertEqual(service.SEGMENT_PROB_ADJUST["Whale"], 0.5)
+        self.assertEqual(service.HOUSE_EDGE["Whale"], 0.2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow configuring user segment probability and house edge from env vars
- document new env variables
- test user segment service env handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68464d8113488329b5e7e8f9465cc218