### PR TITLE
Update roulette service with streak logic

### DIFF
--- a/cc-webapp/backend/app/services/roulette_service.py
+++ b/cc-webapp/backend/app/services/roulette_service.py
@@ -1,14 +1,21 @@
+"""Roulette game service."""
+
 from dataclasses import dataclass
 from typing import Optional
 from sqlalchemy.orm import Session
 import random
+import logging
 
 from .token_service import deduct_tokens, add_tokens, get_balance
 from ..repositories.game_repository import GameRepository
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class RouletteSpinResult:
+    """룰렛 스핀 결과 데이터."""
+
     winning_number: int
     result: str
     tokens_change: int
@@ -22,10 +29,48 @@ class RouletteService:
     def __init__(self, repository: GameRepository | None = None) -> None:
         self.repo = repository or GameRepository()
 
-    def spin(self, user_id: int, bet: int, bet_type: str, value: Optional[str], db: Session) -> RouletteSpinResult:
-        """룰렛 스핀 실행."""
+    def spin(
+        self,
+        user_id: int,
+        bet: int,
+        bet_type: str,
+        value: Optional[str],
+        db: Session,
+    ) -> RouletteSpinResult:
+        """룰렛 스핀을 실행하고 결과를 반환한다.
+
+        Parameters
+        ----------
+        user_id: int
+            사용자 ID
+        bet: int
+            베팅 금액(1~50 사이로 제한)
+        bet_type: str
+            'number', 'color', 'odd_even' 중 하나
+        value: Optional[str]
+            베팅 값 (숫자 또는 색상 등)
+        db: Session
+            데이터베이스 세션
+
+        Returns
+        -------
+        RouletteSpinResult
+            스핀 결과 데이터
+
+        Raises
+        ------
+        ValueError
+            토큰이 부족한 경우
+        """
+
         bet = max(1, min(bet, 50))
-        deduct_tokens(user_id, bet, db)
+        logger.info("룰렛 스핀 시작 user=%s bet=%s type=%s value=%s", user_id, bet, bet_type, value)
+
+        try:
+            deduct_tokens(user_id, bet, db)
+        except ValueError as exc:
+            logger.warning("토큰 차감 실패: %s", exc)
+            raise
 
         segment = self.repo.get_user_segment(db, user_id)
         edge_map = {"Whale": 0.05, "Medium": 0.10, "Low": 0.15}
@@ -36,9 +81,16 @@ class RouletteService:
         result = "lose"
         animation = "lose"
 
+        # 스트릭 정보 (연패 시 승률 보정)
+        streak = self.repo.get_streak(user_id)
+
         if bet_type == "number" and value is not None:
             if number == int(value):
                 payout = int(bet * 35 * (1 - house_edge))
+                if number == 0:
+                    # 0번 적중은 잭팟으로 처리
+                    payout = int(bet * 50 * (1 - house_edge))
+                    animation = "jackpot"
         elif bet_type == "color" and value in {"red", "black"}:
             color_map = {"red": set(range(1, 37, 2)), "black": set(range(2, 37, 2))}
             if number != 0 and number in color_map[value]:
@@ -48,10 +100,19 @@ class RouletteService:
                 payout = int(bet * (1 - house_edge))
 
         if payout:
-            result = "win"
-            animation = "win"
+            result = "win" if animation != "jackpot" else "jackpot"
+            animation = animation if animation != "lose" else "win"
             add_tokens(user_id, payout, db)
+            streak = 0
+        else:
+            streak += 1
 
         balance = get_balance(user_id, db)
+        self.repo.set_streak(user_id, streak)
         self.repo.record_action(db, user_id, "ROULETTE_SPIN", -bet)
+
+        logger.info(
+            "스핀 결과 user=%s number=%s result=%s payout=%s streak=%s", user_id, number, result, payout, streak
+        )
+
         return RouletteSpinResult(number, result, payout - bet, balance, animation)

--- a/cc-webapp/backend/tests/test_roulette_service.py
+++ b/cc-webapp/backend/tests/test_roulette_service.py
@@ -17,16 +17,52 @@ class TestRouletteService(unittest.TestCase):
     @patch("app.services.roulette_service.get_balance", return_value=150)
     @patch("app.services.roulette_service.random.randint", return_value=7)
     def test_spin_win_number(self, m_rand, m_balance, m_add, m_deduct):
+        """숫자 베팅 승리 시 동작을 검증."""
         self.repo.get_user_segment.return_value = "Medium"
+        self.repo.get_streak.return_value = 0
+
         result = self.service.spin(1, 10, "number", "7", self.mock_db)
 
         self.assertIsInstance(result, RouletteSpinResult)
         self.assertEqual(result.result, "win")
         self.assertGreater(result.tokens_change, -10)
         m_add.assert_called_once()
+        self.repo.set_streak.assert_called_once_with(1, 0)
+
+    @patch("app.services.roulette_service.deduct_tokens")
+    @patch("app.services.roulette_service.add_tokens")
+    @patch("app.services.roulette_service.get_balance", return_value=100)
+    @patch("app.services.roulette_service.random.randint", return_value=8)
+    def test_spin_lose_increments_streak(self, m_rand, m_balance, m_add, m_deduct):
+        """패배 시 스트릭 증가 여부를 확인."""
+        self.repo.get_user_segment.return_value = "Medium"
+        self.repo.get_streak.return_value = 1
+
+        result = self.service.spin(1, 10, "number", "7", self.mock_db)
+
+        self.assertEqual(result.result, "lose")
+        self.assertEqual(result.tokens_change, -10)
+        self.repo.set_streak.assert_called_once_with(1, 2)
+
+    @patch("app.services.roulette_service.deduct_tokens")
+    @patch("app.services.roulette_service.add_tokens")
+    @patch("app.services.roulette_service.get_balance", return_value=200)
+    @patch("app.services.roulette_service.random.randint", return_value=0)
+    def test_spin_jackpot(self, m_rand, m_balance, m_add, m_deduct):
+        """0번에 베팅하여 잭팟이 발생하는 경우."""
+        self.repo.get_user_segment.return_value = "Medium"
+        self.repo.get_streak.return_value = 0
+
+        result = self.service.spin(1, 10, "number", "0", self.mock_db)
+
+        self.assertEqual(result.result, "jackpot")
+        self.assertGreater(result.tokens_change, 0)
+        m_add.assert_called_once()
+        self.repo.set_streak.assert_called_once_with(1, 0)
 
     @patch("app.services.roulette_service.deduct_tokens", side_effect=ValueError)
     def test_spin_insufficient_tokens(self, m_deduct):
+        """토큰 부족 시 예외 발생 여부."""
         with self.assertRaises(ValueError):
             self.service.spin(1, 5, "color", "red", self.mock_db)
 


### PR DESCRIPTION
## Summary
- enhance roulette service with logging and streak tracking
- cover jackpot case and losing streak updates
- expand roulette service tests in Korean

## Testing
- `pytest -k roulette_service -q`

------
https://chatgpt.com/codex/tasks/task_e_684656acedb88329a475a56f3b62893f