### PR TITLE
Implement basic frontend MVP

### DIFF
--- a/cc-webapp/frontend/app/page.js
+++ b/cc-webapp/frontend/app/page.js
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import LoginForm from '@/components/LoginForm';
+import TokenDisplay from '@/components/TokenDisplay';
+import GameMenu from '@/components/GameMenu';
+
+export default function HomePage() {
+  const [token, setToken] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('authToken');
+    if (stored) setToken(stored);
+  }, []);
+
+  const handleLogin = (t) => {
+    setToken(t);
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-900 text-white">
+      <header className="p-4 flex justify-between items-center bg-gray-800">
+        <h1 className="text-xl font-bold">Casino MVP</h1>
+        <TokenDisplay token={token} />
+      </header>
+      <main className="flex-grow flex flex-col items-center justify-center p-4">
+        {token ? <GameMenu /> : <LoginForm onLogin={handleLogin} />}
+      </main>
+      <footer className="p-4 text-center text-xs text-gray-400">© 2024 Casino MVP</footer>
+    </div>
+  );
+}

--- a/cc-webapp/frontend/app/slot/page.js
+++ b/cc-webapp/frontend/app/slot/page.js
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import SlotMachine from '@/components/SlotMachine';
+
+export default function SlotPage() {
+  const [token, setToken] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('authToken');
+    if (stored) setToken(stored);
+  }, []);
+
+  if (!token) {
+    return <p className="text-center p-4">Please login first.</p>;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center p-4">
+      <SlotMachine token={token} />
+    </div>
+  );
+}

--- a/cc-webapp/frontend/components/BettingPanel.jsx
+++ b/cc-webapp/frontend/components/BettingPanel.jsx
@@ -1,0 +1,20 @@
+'use client';
+
+export default function BettingPanel({ bet, setBet, balance, disabled }) {
+  const bets = [10, 50, 100];
+
+  return (
+    <div className="flex justify-center space-x-2 mt-4">
+      {bets.map((b) => (
+        <button
+          key={b}
+          onClick={() => setBet(b)}
+          disabled={disabled || balance < b}
+          className={`px-3 py-1 rounded ${bet === b ? 'bg-blue-600' : 'bg-gray-700'} text-white disabled:opacity-40`}
+        >
+          {b}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/cc-webapp/frontend/components/GameMenu.jsx
+++ b/cc-webapp/frontend/components/GameMenu.jsx
@@ -1,0 +1,21 @@
+'use client';
+
+import Link from 'next/link';
+
+export default function GameMenu() {
+  const games = [
+    { name: 'Slot', path: '/slot' },
+    { name: 'Roulette', path: '/roulette' },
+    { name: 'Gacha', path: '/gacha' },
+  ];
+
+  return (
+    <div className="grid grid-cols-3 gap-4 max-w-md mx-auto mt-6">
+      {games.map((g) => (
+        <Link key={g.name} href={g.path} className="bg-gray-700 text-center p-4 rounded-lg text-white hover:bg-gray-600">
+          {g.name}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/cc-webapp/frontend/components/LoginForm.jsx
+++ b/cc-webapp/frontend/components/LoginForm.jsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import { login } from '@/services/auth';
+
+export default function LoginForm({ onLogin }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const data = await login(username, password);
+      const token = data.access_token;
+      localStorage.setItem('authToken', token);
+      onLogin(token);
+    } catch (err) {
+      setError('Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4 bg-gray-800 rounded-lg shadow-lg max-w-sm w-full mx-auto" >
+      <div>
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full p-2 rounded bg-gray-700 text-white"
+        />
+      </div>
+      <div>
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full p-2 rounded bg-gray-700 text-white"
+        />
+      </div>
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full py-2 bg-green-600 rounded text-white disabled:opacity-50"
+      >
+        {loading ? 'Logging in...' : 'Login'}
+      </button>
+    </form>
+  );
+}

--- a/cc-webapp/frontend/components/SlotMachine.jsx
+++ b/cc-webapp/frontend/components/SlotMachine.jsx
@@ -1,211 +1,61 @@
-// cc-webapp/frontend/components/SlotMachine.jsx
 'use client';
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
-import axios from 'axios'; // Or your apiClient
-import { useEmotionFeedback } from '@/hooks/useEmotionFeedback';
-import EmotionFeedback from './EmotionFeedback';
-import useSound from 'use-sound';
-import confetti from 'canvas-confetti';
-import { Zap, Repeat, Gift, ShieldQuestion, PlayCircle } from 'lucide-react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { useState, useEffect } from 'react';
+import SlotReel from './SlotReel';
+import BettingPanel from './BettingPanel';
+import { playSlot } from '@/services/gameApi';
+import '@/styles/slot-animations.css';
 
-// Sound files
-const SPIN_SOUND_PATH = '/sounds/slot_spin.mp3';
-const REEL_STOP_SOUND_PATH = '/sounds/reel_stop.mp3';
-const VICTORY_SOUND_PATH = '/sounds/victory.mp3';
-const FAILURE_SOUND_PATH = '/sounds/failure.mp3';
+const SYMBOLS = ['🍒', '🍋', '🔔', '7'];
 
-// Slot machine configuration
-const SYMBOLS = ['🎰', '🍒', '🔔', '💎', '💰', '🎁', '⭐', '🍊', '🍋']; // Expanded symbols
-const NUM_REELS = 3;
-const REEL_ANIMATION_BASE_DURATION = 1000; // ms for the first reel
-const REEL_STAGGER_DELAY = 250; // ms delay for each subsequent reel stop
-const INDIVIDUAL_SYMBOL_ANIMATION_DURATION = 80; // ms for each symbol change during spin visual
-
-export default function SlotMachine({ userId = 1 }) {
-  const [reels, setReels] = useState(Array(NUM_REELS).fill(SYMBOLS[0]));
+export default function SlotMachine({ token }) {
+  const [reels, setReels] = useState(['🍒', '🍒', '🍒']);
   const [spinning, setSpinning] = useState(false);
-  const [feedback, setFeedback] = useState({ emotion: '', message: '' });
-  const [isFeedbackVisible, setIsFeedbackVisible] = useState(false);
-  const feedbackTimerRef = useRef(null);
-  const reelRefs = useRef([]); // For direct DOM manipulation of reel symbols if needed for complex animation
-
-  const apiClient = axios.create({ baseURL: 'http://localhost:8000/api' });
-  const { fetchEmotionFeedback } = useEmotionFeedback();
-
-  const [playSpinSound, { stop: stopSpinSound }] = useSound(SPIN_SOUND_PATH, { volume: 0.35, loop: true });
-  const [playReelStopSound] = useSound(REEL_STOP_SOUND_PATH, { volume: 0.25 });
-  const [playVictorySound] = useSound(VICTORY_SOUND_PATH, { volume: 0.5 });
-  const [playFailureSound] = useSound(FAILURE_SOUND_PATH, { volume: 0.4 });
+  const [bet, setBet] = useState(10);
+  const [balance, setBalance] = useState(0);
+  const [message, setMessage] = useState('');
 
   useEffect(() => {
-    reelRefs.current = reelRefs.current.slice(0, NUM_REELS); // Initialize refs array
-    return () => { // Cleanup
-      clearTimeout(feedbackTimerRef.current);
-      if (stopSpinSound) stopSpinSound();
-    };
-  }, [stopSpinSound]);
+    // fetch balance when component mounts using TokenDisplay component separately
+  }, []);
 
-  const showFeedbackTemporarily = (emotion, message, duration = 4000) => {
-    setFeedback({ emotion, message });
-    setIsFeedbackVisible(true);
-    if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current);
-    feedbackTimerRef.current = setTimeout(() => setIsFeedbackVisible(false), duration);
-  };
-
-  const triggerConfetti = () => {
-    confetti({ particleCount: 180, spread: 80, origin: { y: 0.55 }, zIndex: 1000, disableForReducedMotion: true, colors: ['#FFD700', '#FF69B4', '#00FFFF', '#7CFC00', '#F08080'] });
-  };
-
-  // Function to simulate one reel's spin animation
-  const animateReel = useCallback((reelIndex, finalSymbol) => {
-    return new Promise((resolve) => {
-      const reelElement = reelRefs.current[reelIndex];
-      if (!reelElement) {
-        resolve(null); // Or handle error
-        return;
-      }
-
-      let animationFrameId;
-      let currentSymbolIndex = 0;
-      const startTime = Date.now();
-      const totalDuration = REEL_ANIMATION_BASE_DURATION + reelIndex * REEL_STAGGER_DELAY;
-
-      const updateSymbol = () => {
-        const elapsedTime = Date.now() - startTime;
-        if (elapsedTime < totalDuration) {
-          currentSymbolIndex = (currentSymbolIndex + 1) % SYMBOLS.length;
-          reelElement.textContent = SYMBOLS[currentSymbolIndex];
-          animationFrameId = setTimeout(updateSymbol, INDIVIDUAL_SYMBOL_ANIMATION_DURATION);
-        } else {
-          reelElement.textContent = finalSymbol;
-          playReelStopSound();
-          resolve(finalSymbol); // Resolve with the final symbol
-        }
-      };
-      updateSymbol();
-    });
-  }, [playReelStopSound]); // SYMBOLS removed as it's constant here
-
-  const handleSpin = async () => {
+  const spin = async () => {
     if (spinning) return;
-
     setSpinning(true);
-    setIsFeedbackVisible(false);
-    if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current);
-    playSpinSound();
-
-    // Initialize reels to a spinning state visually (optional, animateReel handles it)
-    reelRefs.current.forEach(reel => { if(reel) reel.textContent = '🌀'; });
-
+    setMessage('');
     try {
-      // Log action to backend (optimistically)
-      apiClient.post('/actions', {
-        user_id: userId, action_type: "SLOT_SPIN_INITIATED",
-        metadata: { machine_id: "cosmic_slots_v1" },
-        timestamp: new Date().toISOString(),
-      }).catch(err => console.error("Failed to log SLOT_SPIN_INITIATED action:", err));
-
-      // Simulate backend determining the result.
-      // In a real app, this would be an API call: `const result = await apiClient.post('/slots/spin', { userId });`
-      // `result` would contain `{ finalSymbols: ['🍒', '🍒', '💰'], isWin: true, winType: "...", amountWon: ... }`
-      // For this client-side simulation:
-      const finalReelSymbols = Array(NUM_REELS).fill(null).map(() => SYMBOLS[Math.floor(Math.random() * SYMBOLS.length)]);
-
-      // Animate reels to their final symbols
-      const animationPromises = finalReelSymbols.map((symbol, index) => animateReel(index, symbol));
-      await Promise.all(animationPromises);
-
-      stopSpinSound(); // Stop looping spin sound after all reels have stopped
-      setReels(finalReelSymbols); // Update React state with final symbols
-
-      // Determine win/loss based on finalReelSymbols
-      const isWin = finalReelSymbols.every(s => s === finalReelSymbols[0]) || // Three of a kind
-                    (finalReelSymbols.filter(s => s === '💰').length >= 2); // At least two money bags
-      const actionType = isWin ? "SLOT_WIN" : "SLOT_LOSE";
-
-      // Log the outcome action
-       apiClient.post('/actions', {
-        user_id: userId, action_type: actionType,
-        metadata: { machine_id: "cosmic_slots_v1", resultReels: finalReelSymbols },
-        timestamp: new Date().toISOString(),
-      }).catch(err => console.error(`Failed to log ${actionType} action:`, err));
-
-
-      const feedbackResult = await fetchEmotionFeedback(userId, actionType);
-      if (feedbackResult) {
-        showFeedbackTemporarily(feedbackResult.emotion, feedbackResult.message);
-      }
-
-      if (isWin) {
-        playVictorySound();
-        triggerConfetti();
+      const data = await playSlot(token, bet);
+      const { reels: r, payout, remaining_tokens, is_winner } = data.result;
+      setReels(r.map((n) => SYMBOLS[n % SYMBOLS.length]));
+      setBalance(remaining_tokens);
+      if (is_winner) {
+        setMessage(`You won ${payout}!`);
       } else {
-        playFailureSound();
+        setMessage('Try again');
       }
-
-    } catch (error) {
-      console.error("Slot spin process failed:", error);
-      if (stopSpinSound) stopSpinSound();
-      playFailureSound();
-      showFeedbackTemporarily('frustration', 'Spin encountered an issue. Please try again.');
+    } catch (err) {
+      setMessage('Error');
     } finally {
       setSpinning(false);
     }
   };
 
   return (
-    <div className="p-4 sm:p-6 bg-gray-800 text-white border-2 border-purple-700 rounded-xl shadow-2xl text-center max-w-md mx-auto my-4">
-      <header className="mb-6">
-        <motion.div whileHover={{ scale: 1.1, transition:{type:'spring', stiffness:300} }}>
-          <h2 className="text-2xl sm:text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-yellow-400">
-            Cosmic Slots
-          </h2>
-        </motion.div>
-        <p className="text-xs sm:text-sm text-gray-400 mt-1">Spin to win universal treasures!</p>
-      </header>
-
-      <div className="mb-6 sm:mb-8 p-3 sm:p-4 bg-black bg-opacity-40 rounded-lg shadow-inner border border-gray-700">
-        <div className="flex justify-around items-center h-20 sm:h-24 rounded-md overflow-hidden">
-          {Array(NUM_REELS).fill(null).map((_, index) => (
-            <div
-              key={index}
-              ref={el => reelRefs.current[index] = el}
-              className="text-3xl sm:text-5xl w-1/3 h-full flex items-center justify-center bg-gray-700 bg-opacity-50 m-1 rounded shadow-md text-yellow-300"
-              style={{ fontSize: SYMBOL_HEIGHT * 0.75 }} // Dynamic font size based on assumed symbol height
-            >
-              {reels[index]} {/* Initial symbol, updated by animation */}
-            </div>
-          ))}
-        </div>
+    <div className="text-center p-4 bg-gray-800 rounded-lg shadow-lg">
+      <div className="flex justify-center space-x-2 mb-4">
+        {reels.map((s, i) => (
+          <SlotReel key={i} symbol={s} spinning={spinning} />
+        ))}
       </div>
-
-      <motion.button
-        onClick={handleSpin}
+      <BettingPanel bet={bet} setBet={setBet} balance={balance} disabled={spinning} />
+      <button
+        onClick={spin}
         disabled={spinning}
-        className={`w-full px-6 py-3 sm:px-8 sm:py-4 text-white rounded-lg transition-all duration-300 ease-in-out text-lg sm:text-xl font-semibold shadow-lg hover:shadow-xl disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-opacity-75
-          ${spinning
-            ? 'bg-gray-600 cursor-default'
-            : 'bg-gradient-to-r from-green-500 to-teal-500 hover:from-green-600 hover:to-teal-600 focus:ring-green-400'
-          }`}
-        whileHover={{ scale: spinning ? 1 : 1.04 }}
-        whileTap={{ scale: spinning ? 1 : 0.96 }}
+        className="mt-4 px-4 py-2 bg-green-600 rounded text-white disabled:opacity-50"
       >
-        {spinning ? (
-          <div className="flex items-center justify-center">
-            <Repeat size={20} className="animate-spin mr-2.5" /> Spinning...
-          </div>
-        ) : (
-          <div className="flex items-center justify-center">
-            <PlayCircle size={22} className="mr-2" /> Spin Now!
-          </div>
-        )}
-      </motion.button>
-
-      <div className="mt-4 sm:mt-6 min-h-[50px] sm:min-h-[60px]">
-        <EmotionFeedback isVisible={isFeedbackVisible} emotion={feedback.emotion} message={feedback.message} />
-      </div>
+        {spinning ? 'Spinning...' : 'Spin'}
+      </button>
+      {message && <p className="mt-2 text-yellow-400">{message}</p>}
     </div>
   );
 }

--- a/cc-webapp/frontend/components/SlotReel.jsx
+++ b/cc-webapp/frontend/components/SlotReel.jsx
@@ -1,0 +1,6 @@
+'use client';
+
+export default function SlotReel({ symbol, spinning }) {
+  const className = 'reel' + (spinning ? ' spin' : '');
+  return <div className={className}>{symbol}</div>;
+}

--- a/cc-webapp/frontend/components/TokenDisplay.jsx
+++ b/cc-webapp/frontend/components/TokenDisplay.jsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { fetchTokenBalance } from '@/services/auth';
+
+export default function TokenDisplay({ token }) {
+  const [balance, setBalance] = useState(null);
+
+  useEffect(() => {
+    if (!token) return;
+    let mounted = true;
+    fetchTokenBalance(token)
+      .then((data) => {
+        if (mounted) setBalance(data.cyber_tokens);
+      })
+      .catch(() => {
+        if (mounted) setBalance(null);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [token]);
+
+  if (!token) return null;
+
+  return (
+    <div className="text-yellow-400 font-semibold">Tokens: {balance ?? '...'}</div>
+  );
+}

--- a/cc-webapp/frontend/services/auth.js
+++ b/cc-webapp/frontend/services/auth.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+const API_BASE_URL = 'http://localhost:8000';
+
+export async function login(username, password) {
+  const response = await axios.post(`${API_BASE_URL}/auth/login`, {
+    username,
+    password,
+  });
+  return response.data;
+}
+
+export async function fetchTokenBalance(token) {
+  const response = await axios.get(`${API_BASE_URL}/users/me/tokens`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return response.data;
+}

--- a/cc-webapp/frontend/services/gameApi.js
+++ b/cc-webapp/frontend/services/gameApi.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const API_BASE_URL = 'http://localhost:8000';
+
+export async function playSlot(token, betAmount) {
+  const response = await axios.post(
+    `${API_BASE_URL}/games/slot/play`,
+    { bet_amount: betAmount },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return response.data;
+}

--- a/cc-webapp/frontend/styles/slot-animations.css
+++ b/cc-webapp/frontend/styles/slot-animations.css
@@ -1,0 +1,22 @@
+@keyframes spin {
+  from { transform: translateY(0); }
+  to { transform: translateY(-100%); }
+}
+
+.reel {
+  display: inline-block;
+  width: 60px;
+  height: 60px;
+  overflow: hidden;
+  border: 2px solid #555;
+  border-radius: 8px;
+  background: #222;
+  color: #ffeb3b;
+  font-size: 2rem;
+  text-align: center;
+  line-height: 60px;
+}
+
+.reel.spin {
+  animation: spin 0.5s infinite linear;
+}


### PR DESCRIPTION
## Summary
- add login form, token display, and game menu
- implement simple slot machine game page
- create backend API service helpers
- add basic slot animations styles

## Testing
- `npm test` *(fails: cy is not defined)*
- `pytest -q` *(fails: fastapi missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d321b30d083299291352200649215